### PR TITLE
Updated event graph layout for gephi 0.9.

### DIFF
--- a/modules/EventGraphLayout/README.md
+++ b/modules/EventGraphLayout/README.md
@@ -1,0 +1,24 @@
+## EventGraphLayout
+
+Author: Wouter Spekkink (wouterspekkink(at)gmail.com)
+
+This is the source code for the Event Graph Layout plugin for Gephi (http://gephi.org/).
+
+Most of the code used for this layout plugin is the original source code of the Force Atlas 2 plugin. Probably about 99 percent of the code is a stripped-down version of the Force Atlas 2 source code and some minor additions were made to add the options that were required for the event graph layout. Some inspiration for the implementation of the ideas for this plugin was taken from the GeoLayout plugin. The event graph layout plugin was written to allow for the easy creation of event graphs. In an event graph the nodes represent events and the edges/arcs represent relationships between the events (e.g. causality). The layout plugin places the events in a user-specified order on the x-axis. If vertical force is activated, the plugin will push unconnected groups of events away from each other on the y-axis, and keep connected nodes together. The user needs to add numerical variable to the node list and import it as integer, float or double. The variable should indicate the positions of the node on the x-axis. Once activated, the layout plugin will run continuously until the user stops it. If the plugin is activated, then the position of the nodes on the x-axis will remain fixed, but the user is free to move nodes on the y-axis. This is only useful if the user turns of the verticla force option. 
+
+The plugin has only a few controls:
+Scale of order: determines the distance between the nodes on the x-axis.
+Order: a dropdown selection menu to select the user-supplied 'order-variable.'
+Set Vertical Force: turn vertical force on or off. 
+Vertical scale: determines the distance between the nodes on the y-axis.
+Strong Gravity Mode: activates stronger gravity.
+Gravity: set the strength of the gravity.
+Jitter Tolerance: Sets 
+Center: Centers the graph. Sometimes useful for smaller datasets.
+
+An example of an application of the layout plugin is used in a forthcoming publication:
+
+Spekkink, W.A.H. (forthcoming). Building Capacity for Sustainable Regional Industrial Systems: 
+An Event Sequence Analysis of Developments in the Sloe Area and Canal Zone. 
+Accepted for publication in the Journal of Cleaner Production.
+Available online at: http://www.sciencedirect.com/science/article/pii/S0959652614008506

--- a/modules/EventGraphLayout/pom.xml
+++ b/modules/EventGraphLayout/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>gephi-plugin-parent</artifactId>
+        <groupId>org.gephi</groupId>
+        <version>0.9.1</version>
+    </parent>
+
+    <groupId>wouterspekkink</groupId>
+    <artifactId>eventgraphlayout</artifactId>
+    <version>1.0.0</version>
+    <packaging>nbm</packaging>
+
+    <name>EventGraphLayout</name>
+
+
+    <dependencies>
+        <!-- Insert dependencies here -->
+
+        <dependency>
+            <groupId>org.gephi</groupId>
+            <artifactId>layout-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.gephi</groupId>
+            <artifactId>ui-propertyeditor</artifactId>
+        </dependency>
+        <dependency>
+             <groupId>org.gephi</groupId>
+             <artifactId>graph-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-util-lookup</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-util</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>nbm-maven-plugin</artifactId>
+                <configuration>
+                    <licenseName>GPL 3.0</licenseName>
+                    <author>Wouter Spekkink</author>
+                    <authorEmail>wouterspekkink@gmail.com</authorEmail>
+                    <authorUrl>www.wouterspekkink.org</authorUrl>
+                    <sourceCodeUrl>$sourcecode_url</sourceCodeUrl>
+                    <publicPackages>
+                        <!-- Insert public packages -->
+                        <publicPackage></publicPackage>
+                    </publicPackages>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+
+

--- a/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/ForceFactory.java
+++ b/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/ForceFactory.java
@@ -1,0 +1,206 @@
+/*
+ Copyright 2008-2011 Gephi
+ Authors : Mathieu Jacomy <mathieu.jacomy@gmail.com>
+ Website : http://www.gephi.org
+
+ This file is part of Gephi.
+
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+ Copyright 2011 Gephi Consortium. All rights reserved.
+
+ The contents of this file are subject to the terms of either the GNU
+ General Public License Version 3 only ("GPL") or the Common
+ Development and Distribution License("CDDL") (collectively, the
+ "License"). You may not use this file except in compliance with the
+ License. You can obtain a copy of the License at
+ http://gephi.org/about/legal/license-notice/
+ or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+ specific language governing permissions and limitations under the
+ License.  When distributing the software, include this License Header
+ Notice in each file and include the License files at
+ /cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+ License Header, with the fields enclosed by brackets [] replaced by
+ your own identifying information:
+ "Portions Copyrighted [year] [name of copyright owner]"
+
+ If you wish your version of this file to be governed by only the CDDL
+ or only the GPL Version 3, indicate your decision by adding
+ "[Contributor] elects to include this software in this distribution
+ under the [CDDL or GPL Version 3] license." If you do not indicate a
+ single choice of license, a recipient has the option to distribute
+ your version of this file under either the CDDL, the GPL Version 3 or
+ to extend the choice of license to its licensees as provided above.
+ However, if you add GPL Version 3 code and therefore, elected the GPL
+ Version 3 license, then the option applies only if the new code is
+ made subject to such option by the copyright holder.
+
+ This version was edited by Wouter Spekkink (wouterspekkink@gmail.com)
+ in order to keep only the parts of the code that are useful to run
+ the event graph layout plugin. No new code was added.
+  
+
+ Portions Copyrighted 2011 Gephi Consortium.
+ */
+
+package org.wouterspekkink.plugins.layout.eventgraph;
+
+import org.gephi.graph.api.Node;
+
+/**
+ *
+ * @author Mathieu Jacomy
+ */
+public class ForceFactory {
+
+    public static ForceFactory builder = new ForceFactory();
+
+    private ForceFactory() {
+    }
+
+    ;
+
+    public RepulsionForce buildRepulsion(double coefficient) {
+        return new linRepulsion(coefficient);
+    }
+    
+
+    public RepulsionForce getStrongGravity(double coefficient) {
+        return new strongGravity(coefficient);
+    }
+    
+    public AttractionForce buildAttraction(double coefficient) {
+        return new logAttraction_antiCollision(coefficient);
+    }
+    
+    public abstract class AttractionForce {
+
+        public abstract void apply(Node n1, Node n2, double e); // Model for node-node attraction (e is for edge weight if needed)
+    }
+
+    public abstract class RepulsionForce {
+
+        public abstract void apply(Node n1, Node n2);           // Model for node-node repulsion
+
+        public abstract void apply(Node n, double g);           // Model for gravitation (anti-repulsion)
+    }
+    
+    
+    //Repulsion
+    
+    private class linRepulsion extends RepulsionForce {
+
+        private double coefficient;
+
+        public linRepulsion(double c) {
+            coefficient = c;
+        }
+
+        @Override
+        public void apply(Node n1, Node n2) {
+            TimeForceLayoutData n1Layout = n1.getLayoutData();
+            TimeForceLayoutData n2Layout = n2.getLayoutData();
+            
+            // Get the distance
+            double xDist = n1.x() - n2.x();
+            double yDist = n1.y() - n2.y();
+            double distance = (float) Math.sqrt(xDist * xDist + yDist * yDist);
+
+            if (distance > 0) {
+                // NB: factor = force / distance
+                double factor = coefficient * n1Layout.mass * n2Layout.mass / distance / distance;
+
+                n1Layout.dx += xDist * factor;
+                n1Layout.dy += yDist * factor;
+
+                n2Layout.dx -= xDist * factor;
+                n2Layout.dy -= yDist * factor;
+            }
+        }
+        
+        @Override
+        public void apply(Node n, double g) {
+            TimeForceLayoutData nLayout = n.getLayoutData();
+
+            // Get the distance
+            double xDist = n.x();
+            double yDist = n.y();
+            double distance = (float) Math.sqrt(xDist * xDist + yDist * yDist);
+
+            if (distance > 0) {
+                // NB: factor = force / distance
+                double factor = coefficient * nLayout.mass * g / distance;
+
+                nLayout.dx -= xDist * factor;
+                nLayout.dy -= yDist * factor;
+            }
+        }
+    }
+    //Gravity
+         
+    private class strongGravity extends RepulsionForce {
+
+    private double coefficient;
+
+    public strongGravity(double c) {
+       coefficient = c / 2;
+    }
+
+    @Override
+    public void apply(Node n1, Node n2) {
+        // Not Relevant
+    }
+
+    @Override
+    public void apply(Node n, double g) {
+        TimeForceLayoutData nLayout = n.getLayoutData();
+
+        // Get the distance
+        double xDist = n.x();
+        double yDist = n.y();
+        double distance = (float) Math.sqrt(xDist * xDist + yDist * yDist);
+
+        if (distance > 0) {
+            // NB: factor = force / distance
+            double factor = coefficient * nLayout.mass * g;
+
+            nLayout.dx -= xDist * factor;
+            nLayout.dy -= yDist * factor;
+        }
+    }
+    }
+        
+    //Attraction
+    private class logAttraction_antiCollision extends AttractionForce {
+
+        private double coefficient;
+
+        public logAttraction_antiCollision(double c) {
+            coefficient = c;
+        }
+
+        @Override
+        public void apply(Node n1, Node n2, double e) {
+            TimeForceLayoutData n1Layout = n1.getLayoutData();
+            TimeForceLayoutData n2Layout = n2.getLayoutData();
+
+            // Get the distance
+            double xDist = n1.x() - n2.x();
+            double yDist = n1.y() - n2.y();
+            double distance = Math.sqrt(xDist * xDist + yDist * yDist) - n1.size() - n2.size();
+
+            if (distance > 0) {
+
+                // NB: factor = force / distance
+                double factor = -coefficient * e * Math.log(0.5 + distance) / distance; //I changed the 1 to 0.5
+
+                n1Layout.dx += xDist * factor;
+                n1Layout.dy += yDist * factor;
+
+                n2Layout.dx -= xDist * factor;
+                n2Layout.dy -= yDist * factor;
+            }
+        }
+    }    
+    
+}

--- a/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/NodesThread.java
+++ b/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/NodesThread.java
@@ -1,0 +1,91 @@
+/*
+Copyright 2008-2011 Gephi
+Authors : Mathieu Jacomy <mathieu.jacomy@gmail.com>
+Website : http://www.gephi.org
+
+This file is part of Gephi.
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2011 Gephi Consortium. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 3 only ("GPL") or the Common
+Development and Distribution License("CDDL") (collectively, the
+"License"). You may not use this file except in compliance with the
+License. You can obtain a copy of the License at
+http://gephi.org/about/legal/license-notice/
+or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+specific language governing permissions and limitations under the
+License.  When distributing the software, include this License Header
+Notice in each file and include the License files at
+/cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+License Header, with the fields enclosed by brackets [] replaced by
+your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+If you wish your version of this file to be governed by only the CDDL
+or only the GPL Version 3, indicate your decision by adding
+"[Contributor] elects to include this software in this distribution
+under the [CDDL or GPL Version 3] license." If you do not indicate a
+single choice of license, a recipient has the option to distribute
+your version of this file under either the CDDL, the GPL Version 3 or
+to extend the choice of license to its licensees as provided above.
+However, if you add GPL Version 3 code and therefore, elected the GPL
+Version 3 license, then the option applies only if the new code is
+made subject to such option by the copyright holder.
+
+Contributor(s):
+
+Portions Copyrighted 2011 Gephi Consortium.
+ */
+
+package org.wouterspekkink.plugins.layout.eventgraph;
+
+import org.gephi.graph.api.Node;
+import org.wouterspekkink.plugins.layout.eventgraph.ForceFactory.RepulsionForce;
+
+/**
+ *
+ * @author Mathieu Jacomy
+ */
+public class NodesThread implements Runnable{
+    private Node[] nodes;
+    private int from;
+    private int to;
+    private RepulsionForce Repulsion;
+    private double gravity;
+    private RepulsionForce GravityForce;
+    private double scaling;
+
+    public NodesThread(Node[] nodes, int from, int to, double gravity, RepulsionForce GravityForce, double scaling, RepulsionForce Repulsion) {
+        this.nodes = nodes;
+        this.from = from;
+        this.to = to;
+        this.Repulsion = Repulsion;
+        this.gravity = gravity;
+        this.GravityForce = GravityForce;
+        this.scaling = scaling;
+    }
+    
+    @Override
+    public void run() {
+        // Repulsion
+        for (int n1Index = from; n1Index < to; n1Index++) {
+            Node n1 = nodes[n1Index];
+            for (int n2Index = 0; n2Index < n1Index; n2Index++) {
+                Node n2 = nodes[n2Index];
+                Repulsion.apply(n1, n2);
+            }
+        }
+    
+
+    // Gravity
+    for (int nIndex = from; nIndex < to; nIndex++) {
+        Node n = nodes[nIndex];
+        GravityForce.apply(n, gravity / scaling);
+    }
+    }
+}
+    
+

--- a/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/Operation.java
+++ b/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/Operation.java
@@ -1,0 +1,53 @@
+/*
+Copyright 2008-2011 Gephi
+Authors : Mathieu Jacomy <mathieu.jacomy@gmail.com>
+Website : http://www.gephi.org
+
+This file is part of Gephi.
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2011 Gephi Consortium. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 3 only ("GPL") or the Common
+Development and Distribution License("CDDL") (collectively, the
+"License"). You may not use this file except in compliance with the
+License. You can obtain a copy of the License at
+http://gephi.org/about/legal/license-notice/
+or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+specific language governing permissions and limitations under the
+License.  When distributing the software, include this License Header
+Notice in each file and include the License files at
+/cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+License Header, with the fields enclosed by brackets [] replaced by
+your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+If you wish your version of this file to be governed by only the CDDL
+or only the GPL Version 3, indicate your decision by adding
+"[Contributor] elects to include this software in this distribution
+under the [CDDL or GPL Version 3] license." If you do not indicate a
+single choice of license, a recipient has the option to distribute
+your version of this file under either the CDDL, the GPL Version 3 or
+to extend the choice of license to its licensees as provided above.
+However, if you add GPL Version 3 code and therefore, elected the GPL
+Version 3 license, then the option applies only if the new code is
+made subject to such option by the copyright holder.
+
+Contributor(s):
+
+Portions Copyrighted 2011 Gephi Consortium.
+ */
+
+package org.wouterspekkink.plugins.layout.eventgraph;
+
+/**
+ *
+ * @author Mathieu Jacomy
+ */
+public abstract class Operation {
+    
+    public abstract void execute();
+    
+}

--- a/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/OperationNodeNodeAttract.java
+++ b/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/OperationNodeNodeAttract.java
@@ -1,0 +1,51 @@
+/*
+ Copyright 2008-2011 Gephi
+ Authors : Mathieu Jacomy <mathieu.jacomy@gmail.com>
+ Website : http://www.gephi.org
+
+ This file is part of Gephi.
+
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+ Copyright 2011 Gephi Consortium. All rights reserved.
+
+ The contents of this file are subject to the terms of either the GNU
+ General Public License Version 3 only ("GPL") or the Common
+ Development and Distribution License("CDDL") (collectively, the
+ "License"). You may not use this file except in compliance with the
+ License. You can obtain a copy of the License at
+ http://gephi.org/about/legal/license-notice/
+ or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+ specific language governing permissions and limitations under the
+ License.  When distributing the software, include this License Header
+ Notice in each file and include the License files at
+ /cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+ License Header, with the fields enclosed by brackets [] replaced by
+ your own identifying information:
+ "Portions Copyrighted [year] [name of copyright owner]"
+
+ If you wish your version of this file to be governed by only the CDDL
+ or only the GPL Version 3, indicate your decision by adding
+ "[Contributor] elects to include this software in this distribution
+ under the [CDDL or GPL Version 3] license." If you do not indicate a
+ single choice of license, a recipient has the option to distribute
+ your version of this file under either the CDDL, the GPL Version 3 or
+ to extend the choice of license to its licensees as provided above.
+ However, if you add GPL Version 3 code and therefore, elected the GPL
+ Version 3 license, then the option applies only if the new code is
+ made subject to such option by the copyright holder.
+
+ Contributor(s):
+
+ Portions Copyrighted 2011 Gephi Consortium.
+ */
+
+package org.wouterspekkink.plugins.layout.eventgraph;
+
+/**
+ *
+ * @author Mathieu Jacomy
+ */
+public class OperationNodeNodeAttract {
+    
+}

--- a/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/OperationNodeNodeRepulse.java
+++ b/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/OperationNodeNodeRepulse.java
@@ -1,0 +1,68 @@
+/*
+ Copyright 2008-2011 Gephi
+ Authors : Mathieu Jacomy <mathieu.jacomy@gmail.com>
+ Website : http://www.gephi.org
+
+ This file is part of Gephi.
+
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+ Copyright 2011 Gephi Consortium. All rights reserved.
+
+ The contents of this file are subject to the terms of either the GNU
+ General Public License Version 3 only ("GPL") or the Common
+ Development and Distribution License("CDDL") (collectively, the
+ "License"). You may not use this file except in compliance with the
+ License. You can obtain a copy of the License at
+ http://gephi.org/about/legal/license-notice/
+ or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+ specific language governing permissions and limitations under the
+ License.  When distributing the software, include this License Header
+ Notice in each file and include the License files at
+ /cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+ License Header, with the fields enclosed by brackets [] replaced by
+ your own identifying information:
+ "Portions Copyrighted [year] [name of copyright owner]"
+
+ If you wish your version of this file to be governed by only the CDDL
+ or only the GPL Version 3, indicate your decision by adding
+ "[Contributor] elects to include this software in this distribution
+ under the [CDDL or GPL Version 3] license." If you do not indicate a
+ single choice of license, a recipient has the option to distribute
+ your version of this file under either the CDDL, the GPL Version 3 or
+ to extend the choice of license to its licensees as provided above.
+ However, if you add GPL Version 3 code and therefore, elected the GPL
+ Version 3 license, then the option applies only if the new code is
+ made subject to such option by the copyright holder.
+
+ Contributor(s):
+
+ Portions Copyrighted 2011 Gephi Consortium.
+ */
+
+package org.wouterspekkink.plugins.layout.eventgraph;
+
+import org.gephi.graph.api.Node;
+import org.wouterspekkink.plugins.layout.eventgraph.ForceFactory.RepulsionForce;
+
+/**
+ *
+ * @author Mathieu Jacomy
+ */
+public class OperationNodeNodeRepulse extends Operation {
+    private final Node n1;
+    private final Node n2;
+    private final RepulsionForce f;
+
+    public OperationNodeNodeRepulse(Node n1, Node n2, RepulsionForce f) {
+        this.n1 = n1;
+        this.n2 = n2;
+        this.f = f;
+    }
+
+    @Override
+    public void execute() {
+        f.apply(n1, n2);
+    }
+    
+}

--- a/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/OperationNodeRepulse.java
+++ b/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/OperationNodeRepulse.java
@@ -1,0 +1,68 @@
+/*
+Copyright 2008-2011 Gephi
+Authors : Mathieu Jacomy <mathieu.jacomy@gmail.com>
+Website : http://www.gephi.org
+
+This file is part of Gephi.
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2011 Gephi Consortium. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 3 only ("GPL") or the Common
+Development and Distribution License("CDDL") (collectively, the
+"License"). You may not use this file except in compliance with the
+License. You can obtain a copy of the License at
+http://gephi.org/about/legal/license-notice/
+or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+specific language governing permissions and limitations under the
+License.  When distributing the software, include this License Header
+Notice in each file and include the License files at
+/cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+License Header, with the fields enclosed by brackets [] replaced by
+your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+If you wish your version of this file to be governed by only the CDDL
+or only the GPL Version 3, indicate your decision by adding
+"[Contributor] elects to include this software in this distribution
+under the [CDDL or GPL Version 3] license." If you do not indicate a
+single choice of license, a recipient has the option to distribute
+your version of this file under either the CDDL, the GPL Version 3 or
+to extend the choice of license to its licensees as provided above.
+However, if you add GPL Version 3 code and therefore, elected the GPL
+Version 3 license, then the option applies only if the new code is
+made subject to such option by the copyright holder.
+
+Contributor(s):
+
+Portions Copyrighted 2011 Gephi Consortium.
+ */
+
+package org.wouterspekkink.plugins.layout.eventgraph;
+
+import org.gephi.graph.api.Node;
+import org.wouterspekkink.plugins.layout.eventgraph.ForceFactory.RepulsionForce;
+
+/**
+ *
+ * @author Mathieu Jacomy
+ */
+public class OperationNodeRepulse extends Operation {
+    private Node n;
+    private RepulsionForce f;
+    private double coefficient;
+
+    public OperationNodeRepulse(Node n, RepulsionForce f, double coefficient) {
+        this.n = n;
+        this.f = f;
+        this.coefficient = coefficient;
+    }
+
+    @Override
+    public void execute() {
+        f.apply(n, coefficient);
+    }
+    
+}

--- a/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/TimeForce.java
+++ b/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/TimeForce.java
@@ -1,0 +1,489 @@
+/*
+ Copyright 2008-2011 Gephi
+ Authors : Mathieu Jacomy <mathieu.jacomy@gmail.com>
+ Website : http://www.gephi.org
+
+ This file is part of Gephi.
+
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+ Copyright 2011 Gephi Consortium. All rights reserved.
+
+ The contents of this file are subject to the terms of either the GNU
+ General Public License Version 3 only ("GPL") or the Common
+ Development and Distribution License("CDDL") (collectively, the
+ "License"). You may not use this file except in compliance with the
+ License. You can obtain a copy of the License at
+ http://gephi.org/about/legal/license-notice/
+ or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+ specific language governing permissions and limitations under the
+ License.  When distributing the software, include this License Header
+ Notice in each file and include the License files at
+ /cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+ License Header, with the fields enclosed by brackets [] replaced by
+ your own identifying information:
+ "Portions Copyrighted [year] [name of copyright owner]"
+
+ If you wish your version of this file to be governed by only the CDDL
+ or only the GPL Version 3, indicate your decision by adding
+ "[Contributor] elects to include this software in this distribution
+ under the [CDDL or GPL Version 3] license." If you do not indicate a
+ single choice of license, a recipient has the option to distribute
+ your version of this file under either the CDDL, the GPL Version 3 or
+ to extend the choice of license to its licensees as provided above.
+ However, if you add GPL Version 3 code and therefore, elected the GPL
+ Version 3 license, then the option applies only if the new code is
+ made subject to such option by the copyright holder.
+
+ Contributor(s): Wouter Spekkink
+ Contribution: Most of the code is from the original Force Atlas 2 source code
+ Some changes were made to change the way that nodes are laid out in the x-axis
+ The x-axis layout is now based on a variable that should be submitted by the
+ user. The approach used to implement this was inspired by the source dode
+ of the GeoLayout plugin.
+
+ Portions Copyrighted 2011 Gephi Consortium.
+ */
+
+package org.wouterspekkink.plugins.layout.eventgraph;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.gephi.graph.api.Column;
+import org.gephi.graph.api.Edge;
+import org.gephi.graph.api.Graph;
+import org.gephi.graph.api.GraphModel;
+import org.gephi.graph.api.Node;
+import org.gephi.layout.spi.Layout;
+import org.gephi.layout.spi.LayoutBuilder;
+import org.gephi.layout.spi.LayoutProperty;
+import org.gephi.ui.propertyeditor.NodeColumnNumbersEditor;
+import org.openide.util.Exceptions;
+import org.wouterspekkink.plugins.layout.eventgraph.ForceFactory.AttractionForce;
+import org.wouterspekkink.plugins.layout.eventgraph.ForceFactory.RepulsionForce;
+
+/**
+ *
+ * @author wouterspekkink
+ */
+public class TimeForce implements Layout {
+    private GraphModel graphModel;
+    private Graph graph;
+    private final TimeForceBuilder layoutBuilder;
+    private double jitterTolerance;
+    private double scalingRatio;
+    private double orderScale;
+    private Column order;
+    private double gravity;
+    private double speed;
+    private boolean strongGravityMode;
+    private int threadCount;
+    private int currentThreadCount;
+    private ExecutorService pool;
+    private boolean vertical;
+    private boolean center;
+   
+    
+    public TimeForce(TimeForceBuilder layoutBuilder) {
+        this.layoutBuilder = layoutBuilder;
+        this.threadCount = Math.min(4, Math.max(1, Runtime.getRuntime().availableProcessors() - 1));
+        resetPropertiesValues();
+    }
+    
+    @Override
+    public void initAlgo() {
+        speed = 1.;
+
+        graph = graphModel.getGraphVisible();
+
+        graph.readLock();
+        Node[] nodes = graph.getNodes().toArray();
+
+        // Initialise layout data
+        for (Node n : nodes) {
+            if (n.getLayoutData() == null || !(n.getLayoutData() instanceof TimeForceLayoutData)) {
+                TimeForceLayoutData nLayout = new TimeForceLayoutData();
+                n.setLayoutData(nLayout);
+            }
+            TimeForceLayoutData nLayout = n.getLayoutData();
+            nLayout.mass = 1 + graph.getDegree(n);
+            nLayout.old_dx = 0;
+            nLayout.old_dy = 0;
+            nLayout.dx = 0;
+            nLayout.dy = 0;
+        }
+        pool = Executors.newFixedThreadPool(threadCount);
+        currentThreadCount = threadCount;
+                
+        
+        
+
+    }
+    @Override
+    public void goAlgo() {
+        // Initialize graph data
+        if (graphModel == null) {
+            return;
+        }
+        graph = graphModel.getGraphVisible();
+
+        double ord;
+        
+        graph.readLock();
+        Node[] nodes = graph.getNodes().toArray();
+        Edge[] edges = graph.getEdges().toArray();
+        
+        Vector<Node> validNodes = new Vector<Node>();; 
+        Vector<Node> unvalidNodes = new Vector<Node>();;
+
+        for (Node n : nodes) {
+            if(n.getAttribute(order)!=null) {  
+                validNodes.add(n);
+            } else {
+                unvalidNodes.add(n);
+            }
+        }
+          
+        // Initialise layout data
+        for (Node n : nodes) {
+            if (n.getLayoutData() == null || !(n.getLayoutData() instanceof TimeForceLayoutData)) {
+                TimeForceLayoutData nLayout = new TimeForceLayoutData();
+                n.setLayoutData(nLayout);
+            }
+            TimeForceLayoutData nLayout = n.getLayoutData();
+            nLayout.mass = 1 + graph.getDegree(n);
+            nLayout.dx = 0;
+            nLayout.dy = 0;
+            nLayout.old_dx = nLayout.dx;
+            nLayout.old_dy = nLayout.dy;
+
+        }
+        // Repulsion (and gravity)
+        // NB: Muti-threaded
+        RepulsionForce Repulsion = ForceFactory.builder.buildRepulsion(getScalingRatio());
+
+        int taskCount = 8 * currentThreadCount;  // The threadPool Executor Service will manage the fetching of tasks and threads.
+        // We make more tasks than threads because some tasks may need more time to compute.
+        ArrayList<Future> threads = new ArrayList();
+        for (int t = taskCount; t > 0; t--) {
+            int from = (int) Math.floor(nodes.length * (t - 1) / taskCount);
+            int to = (int) Math.floor(nodes.length * t / taskCount);
+            Future future = pool.submit(new NodesThread(nodes, from, to, getGravity(), (isStrongGravityMode()) ? (ForceFactory.builder.getStrongGravity(getScalingRatio())) : (Repulsion), getScalingRatio(), Repulsion));
+            threads.add(future);
+        }
+        for (Future future : threads) {
+            try {
+                future.get();
+            } catch (InterruptedException ex) {
+                Exceptions.printStackTrace(ex);
+            } catch (ExecutionException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        }
+        
+        //Attraction
+        AttractionForce Attraction = ForceFactory.builder.buildAttraction(1);
+        for (Edge e : edges) {
+                Attraction.apply(e.getSource(), e.getTarget(), 1);
+            }
+        // Auto adjust speed
+        double totalSwinging = 0d;  // How much irregular movement
+        double totalEffectiveTraction = 0d;  // Hom much useful movement
+        for (Node n : nodes) {
+            TimeForceLayoutData nLayout = n.getLayoutData();
+            if (!n.isFixed()) {
+                double swinging = Math.sqrt(Math.pow(nLayout.old_dx - nLayout.dx, 2) + Math.pow(nLayout.old_dy - nLayout.dy, 2));
+                totalSwinging += nLayout.mass * swinging;   // If the node has a burst change of direction, then it's not converging.
+                totalEffectiveTraction += nLayout.mass * 0.5 * Math.sqrt(Math.pow(nLayout.old_dx + nLayout.dx, 2) + Math.pow(nLayout.old_dy + nLayout.dy, 2));
+            }
+        }
+        // We want that swingingMovement < tolerance * convergenceMovement
+        double targetSpeed = getJitterTolerance() * getJitterTolerance() * totalEffectiveTraction / totalSwinging;
+
+        // But the speed shoudn't rise too much too quickly, since it would make the convergence drop dramatically.
+        double maxRise = 0.5;   // Max rise: 50%
+        speed = speed + Math.min(targetSpeed - speed, maxRise * speed);
+        
+        // Apply Forces 
+        for (Node n: validNodes) {
+            //AttributeRow row = (AttributeRow) n.getNodeData().getAttributes();
+            TimeForceLayoutData nLayout = n.getLayoutData();
+      
+            if (!n.isFixed()) {
+
+                // Adaptive auto-speed: the speed of each node is lowered
+                // when the node swings.
+                double swinging = Math.sqrt((nLayout.old_dx - nLayout.dx) * (nLayout.old_dx - nLayout.dx) + (nLayout.old_dy - nLayout.dy) * (nLayout.old_dy - nLayout.dy));
+                //double factor = speed / (1f + Math.sqrt(speed * swinging));
+                double factor = speed / (1f + speed * Math.sqrt(swinging));
+
+                double x = n.x() + nLayout.dx * factor;
+                double y = n.y() + nLayout.dy * factor;
+                
+                ord = (Double) n.getAttribute(order, graph.getView());
+                
+                double averageX = 0;
+                double averageY = 0;
+          
+                ord = ord * (double) orderScale;
+                    
+                float ordFloat = (float) ord;
+                n.setX(ordFloat);
+                if (vertical == true) {
+                    n.setY((float) y);
+                } else {
+                    n.setY(n.y());
+                }
+                
+                if (center == true) {
+                    averageX += x;
+                    averageY += y;
+                
+                    averageX = averageX/nodes.length;
+                    averageY = averageY/nodes.length;
+                
+                    x = n.x() - averageX;
+                    y = n.y() - averageY;
+
+                    n.setX((float) x);
+                    n.setY((float) y);
+                    
+                }
+            
+            }
+            
+        }
+        
+        graph.readUnlockAll();
+    }
+        
+
+@Override
+    public boolean canAlgo() {
+        return graphModel != null && order != null;
+    }
+
+    @Override
+    public void endAlgo() {
+        for (Node n : graph.getNodes()) {
+            n.setLayoutData(null);
+        }
+        pool.shutdown();
+        graph.readUnlockAll();
+    }
+    
+    @Override
+    public LayoutProperty[] getProperties() {
+        List<LayoutProperty> properties = new ArrayList<LayoutProperty>();
+        final String TIMEFORCE =  "Time Force Layout";
+        
+        try {
+            properties.add(LayoutProperty.createProperty(
+                    this, Double.class,
+                    "Scale of Order",
+                    TIMEFORCE,
+                    "Determines the separation of the nodes on the x-axis",
+                    "getOrderScale", "setOrderScale"));
+            properties.add(LayoutProperty.createProperty(
+                    this, Column.class,
+                    "Order",
+                    TIMEFORCE,
+                    "Selects the attribute that indicates the order of events",
+                    "getOrder", "setOrder", NodeColumnNumbersEditor.class));
+            properties.add(LayoutProperty.createProperty(
+                    this, Boolean.class,
+                    "Set Vertical Force",
+                    TIMEFORCE,
+                    "Used to push unconnected groups of nodes away from each other",
+                    "isVertical", "setVertical"));
+            properties.add(LayoutProperty.createProperty(
+                    this, Double.class,
+                    "Vertical Scale",
+                    TIMEFORCE,
+                    "Sets the strength of the vertical force",
+                    "getScalingRatio", "setScalingRatio"));
+            properties.add(LayoutProperty.createProperty(
+                    this, Boolean.class,
+                    "Strong Gravity Mode",
+                    TIMEFORCE,
+                    "Sets the strong gravity mode",
+                    "isStrongGravityMode", "setStrongGravityMode"));
+            properties.add(LayoutProperty.createProperty(
+                    this, Double.class,
+                    "Gravity",
+                    TIMEFORCE,
+                    "Pulls nodes to origin of the y-axis. Prevents islands from drifting away.",
+                    "getGravity", "setGravity"));
+            properties.add(LayoutProperty.createProperty(
+                    this, Double.class,
+                    "Jitter Tolerance",
+                    TIMEFORCE,
+                    "How much swiging you allow.",
+                    "getJitterTolerance", "setJitterTolerance"));
+            properties.add(LayoutProperty.createProperty(
+                    this, Integer.class,
+                    "Threads",
+                    TIMEFORCE,
+                    "Possibility to use more threads if your cores can handle it.",
+                    "getThreadsCount", "setThreadsCount"));
+            properties.add(LayoutProperty.createProperty(
+                    this, Boolean.class,
+                    "Center",
+                    TIMEFORCE,
+                    "Centers the graph",
+                    "isCenter", "setCenter"));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return properties.toArray(new LayoutProperty[0]);
+    }
+    
+    @Override
+    public void resetPropertiesValues() {
+        if (graphModel != null) {
+            for (Column c : graphModel.getNodeTable()) {
+                if(c.getId().equalsIgnoreCase("order")
+                    || c.getId().equalsIgnoreCase("ord")
+                    || c.getTitle().equalsIgnoreCase("order")    
+                    || c.getTitle().equalsIgnoreCase("ord")) {
+            order = c;
+        } else {
+               order = null;
+           }
+       }
+        }   
+        int nodesCount = 0;
+
+        if (graphModel != null) {
+            nodesCount = graphModel.getGraphVisible().getNodeCount();
+        }
+
+        setOrderScale(10.0);
+        
+        // Tuning
+        setScalingRatio(1.0);
+        
+        setStrongGravityMode(false);
+        setGravity(1.);
+        
+        setVertical(false);
+        setCenter(false);
+
+        // Performance
+        if (nodesCount >= 50000) {
+            setJitterTolerance(10d);
+        } else if (nodesCount >= 5000) {
+            setJitterTolerance(1d);
+        } else {
+            setJitterTolerance(0.3d);
+        }
+
+        setThreadsCount(2);
+        
+
+        
+    }
+    
+    @Override
+    public LayoutBuilder getBuilder() {
+        return layoutBuilder;
+    }
+
+    @Override
+    public void setGraphModel(GraphModel graphModel) {
+        this.graphModel = graphModel;
+        // Trick: reset here to take the profile of the graph in account for default values
+        resetPropertiesValues();
+    }
+    
+    public Double getJitterTolerance() {
+        return jitterTolerance;
+    }
+
+    public void setJitterTolerance(Double jitterTolerance) {
+        this.jitterTolerance = jitterTolerance;
+    }
+    
+    public Double getScalingRatio() {
+        return scalingRatio;
+    }
+
+    public void setScalingRatio(Double scalingRatio) {
+        this.scalingRatio = scalingRatio;
+    }
+
+    public Boolean isStrongGravityMode() {
+        return strongGravityMode;
+    }
+
+    public void setStrongGravityMode(Boolean strongGravityMode) {
+        this.strongGravityMode = strongGravityMode;
+    }
+    
+    public Boolean isVertical() {
+        return vertical;
+    }
+    
+    public void setVertical(Boolean vertical) {
+        this.vertical = vertical;
+    }
+
+    public Boolean isCenter() {
+        return center;
+    }
+    
+    public void setCenter(Boolean center) {
+        this.center = center;
+    }
+    
+    public Double getGravity() {
+        return gravity;
+    }
+
+    public void setGravity(Double gravity) {
+        this.gravity = gravity;
+    }
+
+    public Integer getThreadsCount() {
+        return threadCount;
+    }
+
+    public void setThreadsCount(Integer threadCount) {
+        if (threadCount < 1) {
+            setThreadsCount(1);
+        } else {
+            this.threadCount = threadCount;
+        }
+    }
+    
+    public Double getOrderScale() {
+        return orderScale;
+    }
+    
+    public void setOrderScale(Double orderScale) {
+        this.orderScale = orderScale;
+    }
+    
+    public Column getOrder() {
+        return order;
+    }
+
+    public void setOrder(Column order) {
+       this.order = order;
+    }
+
+
+
+}
+        
+
+
+
+

--- a/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/TimeForceBuilder.java
+++ b/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/TimeForceBuilder.java
@@ -1,0 +1,104 @@
+/*
+Copyright 2008-2011 Gephi
+Authors : Mathieu Jacomy <mathieu.jacomy@gmail.com>
+Website : http://www.gephi.org
+
+This file is part of Gephi.
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2011 Gephi Consortium. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 3 only ("GPL") or the Common
+Development and Distribution License("CDDL") (collectively, the
+"License"). You may not use this file except in compliance with the
+License. You can obtain a copy of the License at
+http://gephi.org/about/legal/license-notice/
+or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+specific language governing permissions and limitations under the
+License.  When distributing the software, include this License Header
+Notice in each file and include the License files at
+/cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+License Header, with the fields enclosed by brackets [] replaced by
+your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+If you wish your version of this file to be governed by only the CDDL
+or only the GPL Version 3, indicate your decision by adding
+"[Contributor] elects to include this software in this distribution
+under the [CDDL or GPL Version 3] license." If you do not indicate a
+single choice of license, a recipient has the option to distribute
+your version of this file under either the CDDL, the GPL Version 3 or
+to extend the choice of license to its licensees as provided above.
+However, if you add GPL Version 3 code and therefore, elected the GPL
+Version 3 license, then the option applies only if the new code is
+made subject to such option by the copyright holder.
+
+Contributor(s):
+
+Portions Copyrighted 2011 Gephi Consortium.
+ */
+
+package org.wouterspekkink.plugins.layout.eventgraph;
+
+import javax.swing.Icon;
+import javax.swing.JPanel;
+import org.gephi.layout.spi.Layout;
+import org.gephi.layout.spi.LayoutBuilder;
+import org.gephi.layout.spi.LayoutUI;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author Mathieu Jacomy
+ */
+
+@ServiceProvider(service = LayoutBuilder.class)
+public class TimeForceBuilder implements LayoutBuilder {
+    private TimeForceUI ui = new TimeForceUI();
+
+    @Override
+    public String getName() {
+        return "Event Graph Layout";
+    }
+
+    @Override
+    public LayoutUI getUI() {
+        return ui;
+    }
+
+    @Override
+    public TimeForce buildLayout() {
+        TimeForce layout = new TimeForce(this);
+        return layout;
+    }
+
+    private class TimeForceUI implements LayoutUI {
+
+        @Override
+        public String getDescription() {
+            return "A layout plugin for event graphs.";
+        }
+
+        @Override
+        public Icon getIcon() {
+            return null;
+        }
+
+        @Override
+        public JPanel getSimplePanel(Layout layout) {
+            return null;
+        }
+
+        @Override
+        public int getQualityRank() {
+            return 4;
+        }
+
+        @Override
+        public int getSpeedRank() {
+            return 4;
+        }
+    }
+}

--- a/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/TimeForceLayoutData.java
+++ b/modules/EventGraphLayout/src/main/java/org/wouterspekkink/plugins/layout/eventgraph/TimeForceLayoutData.java
@@ -1,0 +1,57 @@
+/*
+Copyright 2008-2011 Gephi
+Authors : Mathieu Jacomy <mathieu.jacomy@gmail.com>
+Website : http://www.gephi.org
+
+This file is part of Gephi.
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2011 Gephi Consortium. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 3 only ("GPL") or the Common
+Development and Distribution License("CDDL") (collectively, the
+"License"). You may not use this file except in compliance with the
+License. You can obtain a copy of the License at
+http://gephi.org/about/legal/license-notice/
+or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+specific language governing permissions and limitations under the
+License.  When distributing the software, include this License Header
+Notice in each file and include the License files at
+/cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+License Header, with the fields enclosed by brackets [] replaced by
+your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+If you wish your version of this file to be governed by only the CDDL
+or only the GPL Version 3, indicate your decision by adding
+"[Contributor] elects to include this software in this distribution
+under the [CDDL or GPL Version 3] license." If you do not indicate a
+single choice of license, a recipient has the option to distribute
+your version of this file under either the CDDL, the GPL Version 3 or
+to extend the choice of license to its licensees as provided above.
+However, if you add GPL Version 3 code and therefore, elected the GPL
+Version 3 license, then the option applies only if the new code is
+made subject to such option by the copyright holder.
+
+Contributor(s):
+
+Portions Copyrighted 2011 Gephi Consortium.
+ */
+
+package org.wouterspekkink.plugins.layout.eventgraph;
+
+import org.gephi.graph.spi.LayoutData;
+
+/**
+ *
+ * @author Mathieu Jacomy
+ */
+public class TimeForceLayoutData implements LayoutData {
+    public double dx = 0;
+    public double dy = 0;
+    public double old_dx = 0;
+    public double old_dy = 0;
+    public double mass = 1;
+}

--- a/modules/EventGraphLayout/src/main/nbm/manifest.mf
+++ b/modules/EventGraphLayout/src/main/nbm/manifest.mf
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+OpenIDE-Module-Name: EventGraphLayout
+OpenIDE-Module-Short-Description: Layout algorithm for event graphs
+OpenIDE-Module-Long-Description: he event graph layout plugin was written to allow for the easy creation of event graphs. In an event graph the nodes represent events and the edges/arcs represent relationships between the events (e.g. causality). The layout plugin places the events in a user-specified order on the x-axis. 
+OpenIDE-Module-Display-Category: Layout

--- a/modules/EventGraphLayout/src/main/nbm/manifest.mf~
+++ b/modules/EventGraphLayout/src/main/nbm/manifest.mf~
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+OpenIDE-Module-Name: EventGraphLayout
+OpenIDE-Module-Short-Description: Layout algorithm for event graphs
+OpenIDE-Module-Long-Description: he event graph layout plugin was written to allow for the easy creation of event graphs. In an event graph the nodes represent events and the edges/arcs represent relationships between the events (e.g. causality). The layout plugin places the events in a user-specified order on the x-axis. If vertical force is activated, the plugin will push unconnected groups of events away from each other on the y-axis, and keep connected nodes together. The user needs to add numerical variable to the node list and import it as integer, float or double. The variable should indicate the positions of the node on the x-axis. Once activated, the layout plugin will run continuously until the user stops it. If the plugin is activated, then the position of the nodes on the x-axis will remain fixed, but the user is free to move nodes on the y-axis. This is only useful if the user turns of the vertical force option. 
+OpenIDE-Module-Display-Category: Layout

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <!-- List of modules -->
     <modules>
         <!-- Add here the paths of all modules (e.g. <module>modules/MyModule</module>) -->
+        <module>modules/EventGraphLayout</module>
     </modules>
     
     <!-- Properties -->


### PR DESCRIPTION
I noticed that floats and Float objects can no longer be cast to Double objects, and that doubles or Double objects cannot be cast into Float objects. This was possible with the previous API of Gephi, as far as I know. Now Gephi will throw an error of such casting is attempted. The same happens with the GeoLayout plugin I have noticed.