### PR TITLE
Image preview plugin to 0.9.X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 **/target/**
+/target/

--- a/modules/gephi-plugin-image-preview/pom.xml
+++ b/modules/gephi-plugin-image-preview/pom.xml
@@ -27,6 +27,7 @@
     <dependency>
       <groupId>org.netbeans.api</groupId>
       <artifactId>org-openide-util-lookup</artifactId>
+        <version>${netbeans.version}</version>
     </dependency>
     <dependency>
       <groupId>org.gephi</groupId>
@@ -39,6 +40,7 @@
     <dependency>
       <groupId>org.netbeans.api</groupId>
       <artifactId>org-openide-util</artifactId>
+        <version>${netbeans.version}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.processing/core -->
     <dependency>
@@ -46,7 +48,27 @@
         <artifactId>core</artifactId>
         <version>3.3.7</version>
     </dependency>
-  </dependencies>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-windows</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-util-ui</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-awt</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-netbeans-modules-settings</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>

--- a/modules/gephi-plugin-image-preview/pom.xml
+++ b/modules/gephi-plugin-image-preview/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>gephi-plugin-parent</artifactId>
+        <groupId>org.gephi</groupId>
+        <version>0.9.2</version>
+    </parent>
+
+    <groupId>org.yale.cs.graphics.gephi</groupId>
+    <artifactId>imagepreview</artifactId>
+    <version>1.0.0</version>
+    <packaging>nbm</packaging>
+
+    <name>gephi-plugin-image-preview</name>
+
+    <dependencies>
+        
+    <dependency>
+      <groupId>org.gephi</groupId>
+      <artifactId>preview-plugin</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.gephi</groupId>
+      <artifactId>core-library-wrapper</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.netbeans.api</groupId>
+      <artifactId>org-openide-util-lookup</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.gephi</groupId>
+      <artifactId>graph-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.gephi</groupId>
+      <artifactId>preview-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.netbeans.api</groupId>
+      <artifactId>org-openide-util</artifactId>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.processing/core -->
+    <dependency>
+        <groupId>org.processing</groupId>
+        <artifactId>core</artifactId>
+        <version>3.3.7</version>
+    </dependency>
+  </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>nbm-maven-plugin</artifactId>
+                <configuration>
+                    <author>Yitzchak Lockerman (Yale Computer Graphics Group)</author>
+                    <sourceCodeUrl>$sourcecode_url</sourceCodeUrl>
+                    <licenseName>Apache 2.0</licenseName>
+                    <publicPackages>
+                        
+                    <publicPackage>org.yale.cs.graphics.gephi.imagepreview</publicPackage>
+                    </publicPackages>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/modules/gephi-plugin-image-preview/src/main/java/org/yale/cs/graphics/gephi/imagepreview/ImageItem.java
+++ b/modules/gephi-plugin-image-preview/src/main/java/org/yale/cs/graphics/gephi/imagepreview/ImageItem.java
@@ -18,13 +18,11 @@ If applicable, add the following below the License Header, with the fields
 enclosed by brackets [] replaced by your own identifying information:
 "Portions Copyrighted [year] [name of copyright owner]"
 
-Contributor(s):
+Contributor(s): Totetmatt (0.9.X Transition)
 
 This file is based on, and meant to be used with, Gephi. (http://gephi.org/)
-*/
-
+ */
 package org.yale.cs.graphics.gephi.imagepreview;
-
 
 import com.itextpdf.text.BadElementException;
 import com.itextpdf.text.Image;
@@ -43,144 +41,128 @@ import processing.core.PImage;
 /**
  * A Item that represents a image within the file system.
  * <p>
- * Each instance of <code>ImageItem</code> represents a single image file. When 
- * the file is loaded (using one of the methods) the image data is cached in 
- * memory, allowing for faster rendering in the future. 
+ * Each instance of <code>ImageItem</code> represents a single image file. When
+ * the file is loaded (using one of the methods) the image data is cached in
+ * memory, allowing for faster rendering in the future.
  * <p>
- * In addition to the cached images, the item contains all the properties of 
- * {@link NodeItem}. 
+ * In addition to the cached images, the item contains all the properties of
+ * {@link NodeItem}.
+ *
  * @author Yitzchak Lockerman
  */
-public class ImageItem extends AbstractItem{
-    
+public class ImageItem extends AbstractItem {
+
     /**
-     * The identifier of this item. 
+     * The identifier of this item.
      */
-    public static final String IMAGE= "Image";
-    
-    
+    public static final String IMAGE = "Image";
+
     /**
-     * The data key for accessing the Processing image file within the cache. 
+     * The data key for accessing the Processing image file within the cache.
      */
-    public static final String PROCESSING_DATA="Processing_Data";
-    
-     /**
-     * The data key for accessing the iText PDF image file within the cache. 
-     */   
-    public static final String PDF_DATA="PDF_Data";
-    
+    public static final String PROCESSING_DATA = "Processing_Data";
+
+    /**
+     * The data key for accessing the iText PDF image file within the cache.
+     */
+    public static final String PDF_DATA = "PDF_Data";
+
     private static final Logger logger = Logger.getLogger(ImageItem.class.getName());
-    
+
     /**
-     * 
+     *
      * @param source The image filename
      */
     public ImageItem(String source) {
         super(source, IMAGE);
     }
-    
+
     /**
-     * Prepares this ImageItem to be rendered by the Processing target. Loading 
-     * from the cache, if available. If the method is forced to load a image 
-     * from the hard drive, it store it in the cache. 
-     * 
+     * Prepares this ImageItem to be rendered by the Processing target. Loading
+     * from the cache, if available. If the method is forced to load a image
+     * from the hard drive, it store it in the cache.
+     *
      * @param location_name The name of the folder to load images from.
      * @param target The properties of the current rendering.
-     * @return A Processing image corresponding to this item. 
+     * @return A Processing image corresponding to this item.
      */
-    public PImage renderProcessing(File location_name,G2DTarget target)
-    {
-        PImage image = (PImage)data.get(PROCESSING_DATA);
-        if(image==null)
-        {
-            if(source instanceof String)
-            {
-                File full_file = new File(location_name,(String)source);
-                try
-                {
+    public PImage renderProcessing(File location_name, G2DTarget target) {
+        PImage image = (PImage) data.get(PROCESSING_DATA);
+        if (image == null) {
+            if (source instanceof String) {
+                File full_file = new File(location_name, (String) source);
+                try {
                     //if(target.getApplet() != null)
                     //    image = target.getApplet().loadImage(full_file.getCanonicalPath());
-                   // else 
+                    // else 
                     //based on http://processing.org/discourse/beta/num_1234546778.html
                     //http://forum.processing.org/topic/converting-bufferedimage-to-pimage
-                    
-                    BufferedImage im_plane = ImageIO.read(full_file);
+                    BufferedImage im_plane;
 
-                    image = new PImage(im_plane.getWidth(),im_plane.getHeight(),PConstants.ARGB );
+                    im_plane = ImageIO.read(full_file);
+                    image = new PImage(im_plane.getWidth(), im_plane.getHeight(), PConstants.ARGB);
                     im_plane.getRGB(0, 0, image.width, image.height, image.pixels, 0, image.width);
                     image.updatePixels();
-                    
-                }
-                catch(java.io.IOException e)
-                {
-                    logger.log(Level.SEVERE, "Unable to load image: "+full_file, e);
+
+                } catch (java.io.IOException e) {
+                    logger.log(Level.SEVERE, "Unable to load image: " + full_file, e);
                 }
             }
-
 
             //If we can't render the image
-            if(image == null)
-            {
+            if (image == null) {
                 logger.log(Level.WARNING, "Unable to load image: {0}", source);
                 return null;
             }
-            
+
             data.put(PROCESSING_DATA, image);
         }
-        
         return image;
     }
-    
+
     /**
      * @param location_name The name of the folder to load images from.
-     * @return The attribute to be added to the SVG file to represent this image.
+     * @return The attribute to be added to the SVG file to represent this
+     * image.
      */
-    public String renderSVG(File location_name)
-    {
-        return "file://" + new File(location_name, (String) this.getSource()).getAbsolutePath();
+    public String renderSVG(File location_name) {
+        return new File(location_name, (String) source).getAbsolutePath();
     }
-    
-     /**
-     * Prepares this ImageItem to be rendered by the PDF target. Loading 
-     * from the cache, if available. If the method is forced to load a image 
-     * from the hard drive, it stores it in the cache. 
-     * 
+
+    /**
+     * Prepares this ImageItem to be rendered by the PDF target. Loading from
+     * the cache, if available. If the method is forced to load a image from the
+     * hard drive, it stores it in the cache.
+     *
      * @param location_name The name of the folder to load images from.
-     * @return A iText PDF Image corresponding to this item. 
-     */   
-    public com.itextpdf.text.Image renderPDF(File location_name)
-    {
-        com.itextpdf.text.Image image = (com.itextpdf.text.Image)data.get(PDF_DATA);
-        if(image==null)
-        {
-            if(source instanceof String)
-            {
-                File full_file = new File(location_name,(String)source);
+     * @return A iText PDF Image corresponding to this item.
+     */
+    public com.itextpdf.text.Image renderPDF(File location_name) {
+        com.itextpdf.text.Image image = (com.itextpdf.text.Image) data.get(PDF_DATA);
+        if (image == null) {
+            if (source instanceof String) {
+                File full_file = new File(location_name,(String) source);
 
                 try {
-                        image = Image.getInstance(full_file.getCanonicalPath());
-
+                    image = Image.getInstance(full_file.getCanonicalPath());
                 } catch (BadElementException ex) {
-                    logger.log(Level.SEVERE, "Unable to load image: "+full_file, ex);
+                    logger.log(Level.SEVERE, "Unable to load image: " + full_file, ex);
                 } catch (MalformedURLException ex) {
-                    logger.log(Level.SEVERE, "Unable to load image: "+full_file, ex);
+                    logger.log(Level.SEVERE, "Unable to load image: " + full_file, ex);
                 } catch (IOException ex) {
-                    logger.log(Level.SEVERE, "Unable to load image: "+full_file, ex);
+                    logger.log(Level.SEVERE, "Unable to load image: " + full_file, ex);
                 }
 
             }
-        
-            
             //If we can't render the image, fallback to the defult render
-            if(image == null)
-            {
+            if (image == null) {
                 logger.log(Level.WARNING, "Unable to load image: {0}", source);
                 return null;
-            }            
-            
+            }
+
             data.put(PDF_DATA, image);
         }
-        
+
         return image;
     }
 }

--- a/modules/gephi-plugin-image-preview/src/main/java/org/yale/cs/graphics/gephi/imagepreview/ImageItem.java
+++ b/modules/gephi-plugin-image-preview/src/main/java/org/yale/cs/graphics/gephi/imagepreview/ImageItem.java
@@ -1,0 +1,186 @@
+/*
+Copyright 2012 Yale Computer Graphics Group
+Authors : Yitzchak Lockerman
+Website : http://graphics.cs.yale.edu/
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2012 Yale Computer Graphics Group. All rights reserved.
+
+The contents of this file are subject to the terms of the GNU
+General Public License Version 3 only ("GPL" or "License"). 
+You may not use this file except in compliance with the
+License. You can obtain a copy of the License at /gpl-3.0.txt.
+See the License for the specific language governing permissions and limitations 
+under the License.  When distributing the software, include this License Header
+Notice in each file and include the License file at /gpl-3.0.txt. 
+If applicable, add the following below the License Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+Contributor(s):
+
+This file is based on, and meant to be used with, Gephi. (http://gephi.org/)
+*/
+
+package org.yale.cs.graphics.gephi.imagepreview;
+
+
+import com.itextpdf.text.BadElementException;
+import com.itextpdf.text.Image;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.imageio.ImageIO;
+import org.gephi.preview.api.G2DTarget;
+import org.gephi.preview.plugin.items.AbstractItem;
+import processing.core.PConstants;
+import processing.core.PImage;
+
+/**
+ * A Item that represents a image within the file system.
+ * <p>
+ * Each instance of <code>ImageItem</code> represents a single image file. When 
+ * the file is loaded (using one of the methods) the image data is cached in 
+ * memory, allowing for faster rendering in the future. 
+ * <p>
+ * In addition to the cached images, the item contains all the properties of 
+ * {@link NodeItem}. 
+ * @author Yitzchak Lockerman
+ */
+public class ImageItem extends AbstractItem{
+    
+    /**
+     * The identifier of this item. 
+     */
+    public static final String IMAGE= "Image";
+    
+    
+    /**
+     * The data key for accessing the Processing image file within the cache. 
+     */
+    public static final String PROCESSING_DATA="Processing_Data";
+    
+     /**
+     * The data key for accessing the iText PDF image file within the cache. 
+     */   
+    public static final String PDF_DATA="PDF_Data";
+    
+    private static final Logger logger = Logger.getLogger(ImageItem.class.getName());
+    
+    /**
+     * 
+     * @param source The image filename
+     */
+    public ImageItem(String source) {
+        super(source, IMAGE);
+    }
+    
+    /**
+     * Prepares this ImageItem to be rendered by the Processing target. Loading 
+     * from the cache, if available. If the method is forced to load a image 
+     * from the hard drive, it store it in the cache. 
+     * 
+     * @param location_name The name of the folder to load images from.
+     * @param target The properties of the current rendering.
+     * @return A Processing image corresponding to this item. 
+     */
+    public PImage renderProcessing(File location_name,G2DTarget target)
+    {
+        PImage image = (PImage)data.get(PROCESSING_DATA);
+        if(image==null)
+        {
+            if(source instanceof String)
+            {
+                File full_file = new File(location_name,(String)source);
+                try
+                {
+                    //if(target.getApplet() != null)
+                    //    image = target.getApplet().loadImage(full_file.getCanonicalPath());
+                   // else 
+                    //based on http://processing.org/discourse/beta/num_1234546778.html
+                    //http://forum.processing.org/topic/converting-bufferedimage-to-pimage
+                    
+                    BufferedImage im_plane = ImageIO.read(full_file);
+
+                    image = new PImage(im_plane.getWidth(),im_plane.getHeight(),PConstants.ARGB );
+                    im_plane.getRGB(0, 0, image.width, image.height, image.pixels, 0, image.width);
+                    image.updatePixels();
+                    
+                }
+                catch(java.io.IOException e)
+                {
+                    logger.log(Level.SEVERE, "Unable to load image: "+full_file, e);
+                }
+            }
+
+
+            //If we can't render the image
+            if(image == null)
+            {
+                logger.log(Level.WARNING, "Unable to load image: {0}", source);
+                return null;
+            }
+            
+            data.put(PROCESSING_DATA, image);
+        }
+        
+        return image;
+    }
+    
+    /**
+     * @param location_name The name of the folder to load images from.
+     * @return The attribute to be added to the SVG file to represent this image.
+     */
+    public String renderSVG(File location_name)
+    {
+        return "file://" + new File(location_name, (String) this.getSource()).getAbsolutePath();
+    }
+    
+     /**
+     * Prepares this ImageItem to be rendered by the PDF target. Loading 
+     * from the cache, if available. If the method is forced to load a image 
+     * from the hard drive, it stores it in the cache. 
+     * 
+     * @param location_name The name of the folder to load images from.
+     * @return A iText PDF Image corresponding to this item. 
+     */   
+    public com.itextpdf.text.Image renderPDF(File location_name)
+    {
+        com.itextpdf.text.Image image = (com.itextpdf.text.Image)data.get(PDF_DATA);
+        if(image==null)
+        {
+            if(source instanceof String)
+            {
+                File full_file = new File(location_name,(String)source);
+
+                try {
+                        image = Image.getInstance(full_file.getCanonicalPath());
+
+                } catch (BadElementException ex) {
+                    logger.log(Level.SEVERE, "Unable to load image: "+full_file, ex);
+                } catch (MalformedURLException ex) {
+                    logger.log(Level.SEVERE, "Unable to load image: "+full_file, ex);
+                } catch (IOException ex) {
+                    logger.log(Level.SEVERE, "Unable to load image: "+full_file, ex);
+                }
+
+            }
+        
+            
+            //If we can't render the image, fallback to the defult render
+            if(image == null)
+            {
+                logger.log(Level.WARNING, "Unable to load image: {0}", source);
+                return null;
+            }            
+            
+            data.put(PDF_DATA, image);
+        }
+        
+        return image;
+    }
+}

--- a/modules/gephi-plugin-image-preview/src/main/java/org/yale/cs/graphics/gephi/imagepreview/ImageNodes.java
+++ b/modules/gephi-plugin-image-preview/src/main/java/org/yale/cs/graphics/gephi/imagepreview/ImageNodes.java
@@ -18,61 +18,58 @@ If applicable, add the following below the License Header, with the fields
 enclosed by brackets [] replaced by your own identifying information:
 "Portions Copyrighted [year] [name of copyright owner]"
 
-Contributor(s):
+Contributor(s): Totetmatt (0.9.X Transition)
 
 This file is based on, and meant to be used with, Gephi. (http://gephi.org/)
-*/
-
+ */
 package org.yale.cs.graphics.gephi.imagepreview;
-
 
 import com.itextpdf.text.DocumentException;
 import com.itextpdf.text.Image;
 import com.itextpdf.text.pdf.PdfContentByte;
 import com.itextpdf.text.pdf.PdfGState;
-import java.awt.Toolkit;
 import java.awt.geom.AffineTransform;
 import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.swing.filechooser.FileSystemView;
 import org.gephi.preview.api.*;
 import org.gephi.preview.plugin.items.NodeItem;
 import org.gephi.preview.plugin.renderers.NodeRenderer;
 import org.gephi.preview.spi.ItemBuilder;
 import org.gephi.preview.spi.Renderer;
 import org.openide.util.NbBundle;
+import org.openide.util.NbPreferences;
 import org.openide.util.lookup.ServiceProvider;
 import org.w3c.dom.Element;
-import processing.core.PGraphics;
 import processing.core.PImage;
 
 /**
- * A service that renders Nodes as images. 
+ * A service that renders Nodes as images.
  * <p>
- * This class works in conjunction with {@link ImageItem} and 
- * {@link NodeImageItemBuilder}. 
+ * This class works in conjunction with {@link ImageItem} and
+ * {@link NodeImageItemBuilder}.
  * <p>
- * This class provides the properties and last step rendering code for the images
- * themselves. It can easily be overloaded to support other images. All that would
- * be needed would be the creation of a new {@link ItemBuilder} that creates
- * proper images. (This class may need to be overidden to modify 
+ * This class provides the properties and last step rendering code for the
+ * images themselves. It can easily be overloaded to support other images. All
+ * that would be needed would be the creation of a new {@link ItemBuilder} that
+ * creates proper images. (This class may need to be overidden to modify
  * <code>needsItemBuilder</code>.
  * <p>
- * 
+ *
  * @author Yirzchak Lockerman (Yale Computer Graphics Group)
  */
-@ServiceProvider(service = Renderer.class, position=200)
-public class ImageNodes implements Renderer{
-    
+@ServiceProvider(service = Renderer.class, position = 200)
+public class ImageNodes implements Renderer {
+
     final static String IMAGE_DESCRIPTION = "ImageNodes.property.imageDescription";
     final static String IMAGE_DIRECTORY = "ImageNodes.property.path";
     final static String IMAGE_OPACITY = "ImageNodes.property.opacity";
+    final static String IMAGE_SCALE ="ImageNodes.property.scale";
     final static String CATEGORY_NODE_IMAGE = "Node Images";
-    
-    private static final Logger logger = Logger.getLogger(ImageNodes.class.getName());
-    
 
-    
+    private static final Logger logger = Logger.getLogger(ImageNodes.class.getName());
+
     @Override
     public String getDisplayName() {
         return NbBundle.getMessage(ImageNodes.class, "ImageNodes.name");
@@ -80,91 +77,72 @@ public class ImageNodes implements Renderer{
 
     @Override
     public void render(Item item, RenderTarget target, PreviewProperties properties) {
-        if(!(item instanceof ImageItem)) return;
-        
+        if (!(item instanceof ImageItem)) {
+            return;
+        }
+
         String imagesPath = properties.getValue(IMAGE_DIRECTORY);
-        if(imagesPath == null || imagesPath.isEmpty()){
+        if (imagesPath == null || imagesPath.isEmpty()) {
             return;
         }
-        
         File imagesDir = new File(imagesPath);
-        if(!imagesDir.exists() || !imagesDir.isDirectory()){
-            return;
-        }
-        
         if (showNodes(properties)) {
             if (target instanceof G2DTarget) {
-                renderImageProcessing((ImageItem)item, (G2DTarget) target, properties, imagesDir);
+                renderImageProcessing((ImageItem) item, (G2DTarget) target, properties, imagesDir);
             } else if (target instanceof SVGTarget) {
-                renderImageSVG((ImageItem)item, (SVGTarget) target, properties, imagesDir);
+                renderImageSVG((ImageItem) item, (SVGTarget) target, properties, imagesDir);
             } else if (target instanceof PDFTarget) {
-                renderImagePDF((ImageItem)item, (PDFTarget) target, properties, imagesDir);
+                renderImagePDF((ImageItem) item, (PDFTarget) target, properties, imagesDir);
             }
         }
-        
+
     }
 
     public void renderImageProcessing(ImageItem item, G2DTarget target, PreviewProperties properties, File directory) {
-        //Graphics
-        
-        //PGraphics graphics = new PGraphics();//target.getGraphics();
-        // PGraphics graphics = target.getGraphics();
-        graphics.pushStyle();
-        
         PImage image = item.renderProcessing(directory, target);
-        
-        if(image == null)
-        {
-            logger.log(Level.WARNING, "Unable to load image: {0}", item.getSource() );
+        if (image == null) {
+            logger.log(Level.WARNING, "Unable to load image: {0}", item.getSource());
             return;
         }
-        
-        //Params
+
         Float x = item.getData(NodeItem.X);
         Float y = item.getData(NodeItem.Y);
         Float size = item.getData(NodeItem.SIZE);
-        Toolkit toolkit = Toolkit.getDefaultToolkit();
-        //java.awt.Image img = toolkit.createImage("C:\\Users\\totetmatt\\Pictures\\max.png");
-        
-        
-        
+
         int alpha = (int) ((properties.getFloatValue(IMAGE_OPACITY) / 100f) * 255f);
         if (alpha > 255) {
             alpha = 255;
         }
-        
-        //target.getGraphics().drawImage(img,new AffineTransform(), null);
-        graphics.imageMode(PGraphics.CENTER);
-        graphics.tint(255, alpha);
-       
-        
-        graphics.image(image,x, y, size, size);
-        
-        
-        graphics.tint(255, 255);
-        graphics.popStyle();
+        /* Taking height of an image as "base" dimention
+           1 - Need to preserve the aspect on the width 
+           2 - Apply a "Image Scale" to adjust the image 
+        */
+        int aspectRatio = size.intValue() * image.width / image.height;
+        int newHeight =(int)(aspectRatio * properties.getFloatValue(IMAGE_SCALE));
+        int newWidth  = (int)(size.intValue()* properties.getFloatValue(IMAGE_SCALE));
+        image.resize(newHeight,newWidth); // There is a AffineTransformation Scale , didn't manage how to properly use it.
+
+        // The AffineTransform will position the image to the center of the "node"
+        target.getGraphics().drawImage(image.getImage(), AffineTransform.getTranslateInstance(x - (image.width / 2), y - (image.height / 2)), null);
+
     }
 
     public void renderImagePDF(ImageItem item, PDFTarget target, PreviewProperties properties, File directory) {
-                      
         Image image = item.renderPDF(directory);
-        
-        if(image == null)
-        {
+
+        if (image == null) {
             logger.log(Level.WARNING, "Unable to load image: {0}", item.getSource());
             return;
         }
-        
+
         Float x = item.getData(NodeItem.X);
         Float y = item.getData(NodeItem.Y);
         Float size = item.getData(NodeItem.SIZE);
-
 
         float alpha = properties.getFloatValue(IMAGE_OPACITY) / 100f;
 
         PdfContentByte cb = target.getContentByte();
 
-        
         if (alpha < 1f) {
             cb.saveState();
             PdfGState gState = new PdfGState();
@@ -172,13 +150,13 @@ public class ImageNodes implements Renderer{
             gState.setStrokeOpacity(alpha);
             cb.setGState(gState);
         }
-        
-        image.setAbsolutePosition(x-size/2, -y-size/2);
+
+        image.setAbsolutePosition(x - size / 2, -y - size / 2);
         image.scaleToFit(size, size);
         try {
             cb.addImage(image);
         } catch (DocumentException ex) {
-            logger.log(Level.SEVERE, "Unable to add image to document: "+item.getSource(), ex);
+            logger.log(Level.SEVERE, "Unable to add image to document: " + item.getSource(), ex);
         }
 
         if (alpha < 1f) {
@@ -186,9 +164,7 @@ public class ImageNodes implements Renderer{
         }
     }
 
-    public void renderImageSVG(ImageItem item, SVGTarget target, PreviewProperties properties, File directory) 
-    {
-        
+    public void renderImageSVG(ImageItem item, SVGTarget target, PreviewProperties properties, File directory) {
         //Params
         Float x = item.getData(NodeItem.X);
         Float y = item.getData(NodeItem.Y);
@@ -200,64 +176,70 @@ public class ImageNodes implements Renderer{
         }
 
         Element nodeElem = target.createElement("image");
-        nodeElem.setAttribute("class", "node" );
-        nodeElem.setAttribute("xlink:href",(String)item.renderSVG(directory));
-        nodeElem.setAttribute("x", ""+(x-size/2));
-        nodeElem.setAttribute("y", ""+(y-size/2));
-        
+        nodeElem.setAttribute("class", "node");
+        nodeElem.setAttribute("xlink:href", (String) item.renderSVG(directory));
+        nodeElem.setAttribute("x", "" + (x - size / 2));
+        nodeElem.setAttribute("y", "" + (y - size / 2));
+
         nodeElem.setAttribute("width", size.toString());
         nodeElem.setAttribute("height", size.toString());
-        nodeElem.setAttribute("style", "opacity: "+alpha);
+        nodeElem.setAttribute("style", "opacity: " + alpha);
 
         target.getTopElement(SVGTarget.TOP_NODES).appendChild(nodeElem);
     }
-    
+
     @Override
     public void preProcess(PreviewModel previewModel) {
+        NbPreferences.forModule(NodeImageItemBuilder.class)
+                .put("ImageNodes.imageDirectory", (String)previewModel.getProperties().getValue(IMAGE_DIRECTORY));
     }
     
+    private String getImageDirectory() {
+        return NbPreferences.forModule(NodeImageItemBuilder.class)
+                .get("ImageNodes.imageDirectory", FileSystemView.getFileSystemView().getDefaultDirectory().getAbsolutePath());
+    }
+
     @Override
     public PreviewProperty[] getProperties() {
         return new PreviewProperty[]{
             PreviewProperty.createProperty(this, "ImageNodes.property.enable", Boolean.class,
-               NbBundle.getMessage(ImageNodes.class, "ImageNodes.property.enable.name"),
-               NbBundle.getMessage(ImageNodes.class, "ImageNodes.property.enable.description"),
-              CATEGORY_NODE_IMAGE).setValue(false),
-            /*PreviewProperty.createProperty(this, IMAGE_DESCRIPTION, String.class,
-                NbBundle.getMessage(ImageNodes.class, IMAGE_DESCRIPTION+".name"),
-                NbBundle.getMessage(ImageNodes.class, IMAGE_DESCRIPTION+".description"),
-                PreviewProperty.CATEGORY_NODES,"ImageNodes.property.enable").setValue("image"),*/
+            NbBundle.getMessage(ImageNodes.class, "ImageNodes.property.enable.name"),
+            NbBundle.getMessage(ImageNodes.class, "ImageNodes.property.enable.description"),
+            CATEGORY_NODE_IMAGE).setValue(false),
             PreviewProperty.createProperty(this, IMAGE_DIRECTORY, String.class,
-                NbBundle.getMessage(ImageNodes.class, IMAGE_DIRECTORY+".name"),
-                NbBundle.getMessage(ImageNodes.class, IMAGE_DIRECTORY+".description"),
-                CATEGORY_NODE_IMAGE,"ImageNodes.property.enable").setValue(new File(".").getAbsolutePath()),
+            NbBundle.getMessage(ImageNodes.class, IMAGE_DIRECTORY + ".name"),
+            NbBundle.getMessage(ImageNodes.class, IMAGE_DIRECTORY + ".description"),
+            CATEGORY_NODE_IMAGE, "ImageNodes.property.enable").setValue(getImageDirectory()), // Default to home document
             PreviewProperty.createProperty(this, IMAGE_OPACITY, Float.class,
-                NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.opacity.displayName"),
-                NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.opacity.description"),
-                CATEGORY_NODE_IMAGE,"ImageNodes.property.enable").setValue(100f)};
+            NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.opacity.displayName"),
+            NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.opacity.description"),
+            CATEGORY_NODE_IMAGE, "ImageNodes.property.enable").setValue(100f),
+            PreviewProperty.createProperty(this, IMAGE_SCALE, Float.class,
+            NbBundle.getMessage(ImageNodes.class, IMAGE_SCALE + ".name"),
+            NbBundle.getMessage(ImageNodes.class, IMAGE_SCALE + ".description"),
+            CATEGORY_NODE_IMAGE, "ImageNodes.property.enable").setValue(1f)};
 
-    }  
-    
-    private boolean showNodes(PreviewProperties properties){
+    }
+
+    private boolean showNodes(PreviewProperties properties) {
         return properties.getFloatValue(IMAGE_OPACITY) > 0 && properties.getBooleanValue("ImageNodes.property.enable");
     }
-     
+
     @Override
     public boolean isRendererForitem(Item item, PreviewProperties properties) {
-
-            if(!(item instanceof ImageItem))
-                return false;
-
-            return showNodes(properties) && item.getSource() != null && item.getSource() instanceof String;
-
+        if (!(item instanceof ImageItem)) {
+            return false;
+        }
+        return showNodes(properties) && item.getSource() != null && item.getSource() instanceof String;
     }
-        
+
     @Override
     public boolean needsItemBuilder(ItemBuilder itemBuilder, PreviewProperties properties) {
         return itemBuilder instanceof NodeImageItemBuilder && showNodes(properties);
     }
 
+    @Override
     public CanvasSize getCanvasSize(Item item, PreviewProperties pp) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        return new CanvasSize();
     }
 }

--- a/modules/gephi-plugin-image-preview/src/main/java/org/yale/cs/graphics/gephi/imagepreview/ImageNodes.java
+++ b/modules/gephi-plugin-image-preview/src/main/java/org/yale/cs/graphics/gephi/imagepreview/ImageNodes.java
@@ -1,0 +1,263 @@
+/*
+Copyright 2012 Yale Computer Graphics Group
+Authors : Yitzchak Lockerman
+Website : http://graphics.cs.yale.edu/
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2012 Yale Computer Graphics Group. All rights reserved.
+
+The contents of this file are subject to the terms of  the GNU
+General Public License Version 3 only ("GPL" or "License"). 
+You may not use this file except in compliance with the
+License. You can obtain a copy of the License at /gpl-3.0.txt.
+See the License for the specific language governing permissions and limitations 
+under the License.  When distributing the software, include this License Header
+Notice in each file and include the License file at /gpl-3.0.txt. 
+If applicable, add the following below the License Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+Contributor(s):
+
+This file is based on, and meant to be used with, Gephi. (http://gephi.org/)
+*/
+
+package org.yale.cs.graphics.gephi.imagepreview;
+
+
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.Image;
+import com.itextpdf.text.pdf.PdfContentByte;
+import com.itextpdf.text.pdf.PdfGState;
+import java.awt.Toolkit;
+import java.awt.geom.AffineTransform;
+import java.io.File;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.gephi.preview.api.*;
+import org.gephi.preview.plugin.items.NodeItem;
+import org.gephi.preview.plugin.renderers.NodeRenderer;
+import org.gephi.preview.spi.ItemBuilder;
+import org.gephi.preview.spi.Renderer;
+import org.openide.util.NbBundle;
+import org.openide.util.lookup.ServiceProvider;
+import org.w3c.dom.Element;
+import processing.core.PGraphics;
+import processing.core.PImage;
+
+/**
+ * A service that renders Nodes as images. 
+ * <p>
+ * This class works in conjunction with {@link ImageItem} and 
+ * {@link NodeImageItemBuilder}. 
+ * <p>
+ * This class provides the properties and last step rendering code for the images
+ * themselves. It can easily be overloaded to support other images. All that would
+ * be needed would be the creation of a new {@link ItemBuilder} that creates
+ * proper images. (This class may need to be overidden to modify 
+ * <code>needsItemBuilder</code>.
+ * <p>
+ * 
+ * @author Yirzchak Lockerman (Yale Computer Graphics Group)
+ */
+@ServiceProvider(service = Renderer.class, position=200)
+public class ImageNodes implements Renderer{
+    
+    final static String IMAGE_DESCRIPTION = "ImageNodes.property.imageDescription";
+    final static String IMAGE_DIRECTORY = "ImageNodes.property.path";
+    final static String IMAGE_OPACITY = "ImageNodes.property.opacity";
+    final static String CATEGORY_NODE_IMAGE = "Node Images";
+    
+    private static final Logger logger = Logger.getLogger(ImageNodes.class.getName());
+    
+
+    
+    @Override
+    public String getDisplayName() {
+        return NbBundle.getMessage(ImageNodes.class, "ImageNodes.name");
+    }
+
+    @Override
+    public void render(Item item, RenderTarget target, PreviewProperties properties) {
+        if(!(item instanceof ImageItem)) return;
+        
+        String imagesPath = properties.getValue(IMAGE_DIRECTORY);
+        if(imagesPath == null || imagesPath.isEmpty()){
+            return;
+        }
+        
+        File imagesDir = new File(imagesPath);
+        if(!imagesDir.exists() || !imagesDir.isDirectory()){
+            return;
+        }
+        
+        if (showNodes(properties)) {
+            if (target instanceof G2DTarget) {
+                renderImageProcessing((ImageItem)item, (G2DTarget) target, properties, imagesDir);
+            } else if (target instanceof SVGTarget) {
+                renderImageSVG((ImageItem)item, (SVGTarget) target, properties, imagesDir);
+            } else if (target instanceof PDFTarget) {
+                renderImagePDF((ImageItem)item, (PDFTarget) target, properties, imagesDir);
+            }
+        }
+        
+    }
+
+    public void renderImageProcessing(ImageItem item, G2DTarget target, PreviewProperties properties, File directory) {
+        //Graphics
+        
+        //PGraphics graphics = new PGraphics();//target.getGraphics();
+        // PGraphics graphics = target.getGraphics();
+        graphics.pushStyle();
+        
+        PImage image = item.renderProcessing(directory, target);
+        
+        if(image == null)
+        {
+            logger.log(Level.WARNING, "Unable to load image: {0}", item.getSource() );
+            return;
+        }
+        
+        //Params
+        Float x = item.getData(NodeItem.X);
+        Float y = item.getData(NodeItem.Y);
+        Float size = item.getData(NodeItem.SIZE);
+        Toolkit toolkit = Toolkit.getDefaultToolkit();
+        //java.awt.Image img = toolkit.createImage("C:\\Users\\totetmatt\\Pictures\\max.png");
+        
+        
+        
+        int alpha = (int) ((properties.getFloatValue(IMAGE_OPACITY) / 100f) * 255f);
+        if (alpha > 255) {
+            alpha = 255;
+        }
+        
+        //target.getGraphics().drawImage(img,new AffineTransform(), null);
+        graphics.imageMode(PGraphics.CENTER);
+        graphics.tint(255, alpha);
+       
+        
+        graphics.image(image,x, y, size, size);
+        
+        
+        graphics.tint(255, 255);
+        graphics.popStyle();
+    }
+
+    public void renderImagePDF(ImageItem item, PDFTarget target, PreviewProperties properties, File directory) {
+                      
+        Image image = item.renderPDF(directory);
+        
+        if(image == null)
+        {
+            logger.log(Level.WARNING, "Unable to load image: {0}", item.getSource());
+            return;
+        }
+        
+        Float x = item.getData(NodeItem.X);
+        Float y = item.getData(NodeItem.Y);
+        Float size = item.getData(NodeItem.SIZE);
+
+
+        float alpha = properties.getFloatValue(IMAGE_OPACITY) / 100f;
+
+        PdfContentByte cb = target.getContentByte();
+
+        
+        if (alpha < 1f) {
+            cb.saveState();
+            PdfGState gState = new PdfGState();
+            gState.setFillOpacity(alpha);
+            gState.setStrokeOpacity(alpha);
+            cb.setGState(gState);
+        }
+        
+        image.setAbsolutePosition(x-size/2, -y-size/2);
+        image.scaleToFit(size, size);
+        try {
+            cb.addImage(image);
+        } catch (DocumentException ex) {
+            logger.log(Level.SEVERE, "Unable to add image to document: "+item.getSource(), ex);
+        }
+
+        if (alpha < 1f) {
+            cb.restoreState();
+        }
+    }
+
+    public void renderImageSVG(ImageItem item, SVGTarget target, PreviewProperties properties, File directory) 
+    {
+        
+        //Params
+        Float x = item.getData(NodeItem.X);
+        Float y = item.getData(NodeItem.Y);
+        Float size = item.getData(NodeItem.SIZE);
+
+        float alpha = properties.getFloatValue(IMAGE_OPACITY) / 100f;
+        if (alpha > 1) {
+            alpha = 1;
+        }
+
+        Element nodeElem = target.createElement("image");
+        nodeElem.setAttribute("class", "node" );
+        nodeElem.setAttribute("xlink:href",(String)item.renderSVG(directory));
+        nodeElem.setAttribute("x", ""+(x-size/2));
+        nodeElem.setAttribute("y", ""+(y-size/2));
+        
+        nodeElem.setAttribute("width", size.toString());
+        nodeElem.setAttribute("height", size.toString());
+        nodeElem.setAttribute("style", "opacity: "+alpha);
+
+        target.getTopElement(SVGTarget.TOP_NODES).appendChild(nodeElem);
+    }
+    
+    @Override
+    public void preProcess(PreviewModel previewModel) {
+    }
+    
+    @Override
+    public PreviewProperty[] getProperties() {
+        return new PreviewProperty[]{
+            PreviewProperty.createProperty(this, "ImageNodes.property.enable", Boolean.class,
+               NbBundle.getMessage(ImageNodes.class, "ImageNodes.property.enable.name"),
+               NbBundle.getMessage(ImageNodes.class, "ImageNodes.property.enable.description"),
+              CATEGORY_NODE_IMAGE).setValue(false),
+            /*PreviewProperty.createProperty(this, IMAGE_DESCRIPTION, String.class,
+                NbBundle.getMessage(ImageNodes.class, IMAGE_DESCRIPTION+".name"),
+                NbBundle.getMessage(ImageNodes.class, IMAGE_DESCRIPTION+".description"),
+                PreviewProperty.CATEGORY_NODES,"ImageNodes.property.enable").setValue("image"),*/
+            PreviewProperty.createProperty(this, IMAGE_DIRECTORY, String.class,
+                NbBundle.getMessage(ImageNodes.class, IMAGE_DIRECTORY+".name"),
+                NbBundle.getMessage(ImageNodes.class, IMAGE_DIRECTORY+".description"),
+                CATEGORY_NODE_IMAGE,"ImageNodes.property.enable").setValue(new File(".").getAbsolutePath()),
+            PreviewProperty.createProperty(this, IMAGE_OPACITY, Float.class,
+                NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.opacity.displayName"),
+                NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.opacity.description"),
+                CATEGORY_NODE_IMAGE,"ImageNodes.property.enable").setValue(100f)};
+
+    }  
+    
+    private boolean showNodes(PreviewProperties properties){
+        return properties.getFloatValue(IMAGE_OPACITY) > 0 && properties.getBooleanValue("ImageNodes.property.enable");
+    }
+     
+    @Override
+    public boolean isRendererForitem(Item item, PreviewProperties properties) {
+
+            if(!(item instanceof ImageItem))
+                return false;
+
+            return showNodes(properties) && item.getSource() != null && item.getSource() instanceof String;
+
+    }
+        
+    @Override
+    public boolean needsItemBuilder(ItemBuilder itemBuilder, PreviewProperties properties) {
+        return itemBuilder instanceof NodeImageItemBuilder && showNodes(properties);
+    }
+
+    public CanvasSize getCanvasSize(Item item, PreviewProperties pp) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+}

--- a/modules/gephi-plugin-image-preview/src/main/java/org/yale/cs/graphics/gephi/imagepreview/NodeImageItemBuilder.java
+++ b/modules/gephi-plugin-image-preview/src/main/java/org/yale/cs/graphics/gephi/imagepreview/NodeImageItemBuilder.java
@@ -18,7 +18,7 @@ If applicable, add the following below the License Header, with the fields
 enclosed by brackets [] replaced by your own identifying information:
 "Portions Copyrighted [year] [name of copyright owner]"
 
-Contributor(s):
+Contributor(s): Totetmatt (0.9.X Transition)
 
 This file is based on, and meant to be used with, Gephi. (http://gephi.org/)
 */
@@ -26,6 +26,8 @@ This file is based on, and meant to be used with, Gephi. (http://gephi.org/)
 package org.yale.cs.graphics.gephi.imagepreview;
 
 import java.awt.Color;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.gephi.graph.api.Column;
 import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.Node;
@@ -41,28 +43,30 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service=ItemBuilder.class)
 public class NodeImageItemBuilder implements ItemBuilder{
-
+    private static final Logger logger = Logger.getLogger(NodeImageItemBuilder.class.getName());
     @Override
     public Item[] getItems(Graph graph) {
 
         Item[] items = new ImageItem[graph.getNodeCount()];
         
         int i = 0;
-        
-        for (Node n : graph.getNodes()) {
-            
-            //ImageItem imageItem = new ImageItem((String)n.getAttribute("image"));
-            ImageItem imageItem = new ImageItem("C:\\Users\\totetmatt\\Pictures\\max.png");
-            imageItem.setData(NodeItem.X, n.x());
-            imageItem.setData(NodeItem.Y, -n.y());
-            imageItem.setData(NodeItem.Z, n.z());
-            imageItem.setData(NodeItem.SIZE, n.size() * 2f);
-            imageItem.setData(NodeItem.COLOR, new Color((int) (n.r() * 255),
-                    (int) (n.g() * 255),
-                    (int) (n.b() * 255),
-                    (int) (n.alpha() * 255)));
-            items[i++] = imageItem;
-        }
+        try {
+            for (Node n : graph.getNodes()) {
+                ImageItem imageItem = new ImageItem((String)n.getAttribute("image"));
+                imageItem.setData(NodeItem.X, n.x());
+                imageItem.setData(NodeItem.Y, -n.y());
+                imageItem.setData(NodeItem.Z, n.z());
+                imageItem.setData(NodeItem.SIZE, n.size() * 2f);
+                imageItem.setData(NodeItem.COLOR, new Color((int) (n.r() * 255),
+                        (int) (n.g() * 255),
+                        (int) (n.b() * 255),
+                        (int) (n.alpha() * 255)));
+                items[i++] = imageItem;
+            }
+        } catch (Exception e){
+            items = new ImageItem[0];
+            logger.log(Level.SEVERE,null,e);
+        } 
         return items;
     }
 

--- a/modules/gephi-plugin-image-preview/src/main/java/org/yale/cs/graphics/gephi/imagepreview/NodeImageItemBuilder.java
+++ b/modules/gephi-plugin-image-preview/src/main/java/org/yale/cs/graphics/gephi/imagepreview/NodeImageItemBuilder.java
@@ -1,0 +1,75 @@
+/*
+Copyright 2012 Yale Computer Graphics Group
+Authors : Yitzchak Lockerman
+Website : http://graphics.cs.yale.edu/
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2012 Yale Computer Graphics Group. All rights reserved.
+
+The contents of this file are subject to the terms of the GNU
+General Public License Version 3 only ("GPL" or "License"). 
+You may not use this file except in compliance with the
+License. You can obtain a copy of the License at /gpl-3.0.txt.
+See the License for the specific language governing permissions and limitations 
+under the License.  When distributing the software, include this License Header
+Notice in each file and include the License file at /gpl-3.0.txt. 
+If applicable, add the following below the License Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+Contributor(s):
+
+This file is based on, and meant to be used with, Gephi. (http://gephi.org/)
+*/
+
+package org.yale.cs.graphics.gephi.imagepreview;
+
+import java.awt.Color;
+import org.gephi.graph.api.Column;
+import org.gephi.graph.api.Graph;
+import org.gephi.graph.api.Node;
+import org.gephi.preview.api.Item;
+import org.gephi.preview.plugin.items.NodeItem;
+import org.gephi.preview.spi.ItemBuilder;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * This is a simple class that creates an {@link ImageItem} for each node.
+ * 
+ * @author Yitzchak Lockerman
+ */
+@ServiceProvider(service=ItemBuilder.class)
+public class NodeImageItemBuilder implements ItemBuilder{
+
+    @Override
+    public Item[] getItems(Graph graph) {
+
+        Item[] items = new ImageItem[graph.getNodeCount()];
+        
+        int i = 0;
+        
+        for (Node n : graph.getNodes()) {
+            
+            //ImageItem imageItem = new ImageItem((String)n.getAttribute("image"));
+            ImageItem imageItem = new ImageItem("C:\\Users\\totetmatt\\Pictures\\max.png");
+            imageItem.setData(NodeItem.X, n.x());
+            imageItem.setData(NodeItem.Y, -n.y());
+            imageItem.setData(NodeItem.Z, n.z());
+            imageItem.setData(NodeItem.SIZE, n.size() * 2f);
+            imageItem.setData(NodeItem.COLOR, new Color((int) (n.r() * 255),
+                    (int) (n.g() * 255),
+                    (int) (n.b() * 255),
+                    (int) (n.alpha() * 255)));
+            items[i++] = imageItem;
+        }
+        return items;
+    }
+
+    @Override
+    public String getType() {
+        return ImageItem.IMAGE;
+    }
+    
+    
+}

--- a/modules/gephi-plugin-image-preview/src/main/nbm/manifest.mf
+++ b/modules/gephi-plugin-image-preview/src/main/nbm/manifest.mf
@@ -1,6 +1,7 @@
 Manifest-Version: 1.3
 OpenIDE-Module-Localizing-Bundle: org/yale/cs/graphics/gephi/imagepreview/Bundle.properties
 OpenIDE-Module-Name: Image Preview
+OpenIDE-Module-Requires: org.openide.windows.WindowManager
 OpenIDE-Module-Short-Description: Image Preview
 OpenIDE-Module-Long-Description: Image Preview
 OpenIDE-Module-Display-Category: Preview

--- a/modules/gephi-plugin-image-preview/src/main/nbm/manifest.mf
+++ b/modules/gephi-plugin-image-preview/src/main/nbm/manifest.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.3
+OpenIDE-Module-Localizing-Bundle: org/yale/cs/graphics/gephi/imagepreview/Bundle.properties
+OpenIDE-Module-Name: Image Preview
+OpenIDE-Module-Short-Description: Image Preview
+OpenIDE-Module-Long-Description: Image Preview
+OpenIDE-Module-Display-Category: Preview

--- a/modules/gephi-plugin-image-preview/src/main/resources/org/yale/cs/graphics/gephi/imagepreview/Bundle.properties
+++ b/modules/gephi-plugin-image-preview/src/main/resources/org/yale/cs/graphics/gephi/imagepreview/Bundle.properties
@@ -1,0 +1,37 @@
+OpenIDE-Module-Display-Category=Preview
+OpenIDE-Module-Long-Description=\
+    Preview plugin that allows you to render images as nodes. <br/> <br/> \
+    Each node (that has a image) must have an attribute called 'image', which \
+    contains the filename of the image file. Images are loaded relative to a \
+    given <i>Image Path</i> property in the Preview Property window. <br/> <br/>\
+    Please reset Gephi after this plugin is installed, and remember to enable it\
+    with the <i>Render Nodes As Images</i> property in the Preview Property window.
+    
+
+OpenIDE-Module-Name=Image Preview
+OpenIDE-Module-Short-Description=Image Preview
+
+ImageNodes.name=Image Nodes
+
+ImageNodes.property.enable.name=Render Nodes As Images
+ImageNodes.property.enable.description= Allows you to render nodes as an image.\
+    The image name must be provided by an attribute named image. Image file \
+    names must be relative to <i>Image Path</i>.\n \
+    Images should be square, and will be scaled based on the size of the node.\
+    Note that only the names of the files will be exported to SVG output. To \
+    see those images when viewing the SVG file, make sure it is stored in \
+    the <i>Image Path<\i>.
+
+ImageNodes.property.imageDescription.name= Image Property
+ImageNodes.property.imageDescription.description = \
+    The node attribute that describes the image. Each node should have an\
+    attribute with the given name listing the filename of the image that is to\
+    be used to represent the node. The image will be loaded relative to the \
+    <i>Image Path<\i> property. 
+
+ImageNodes.property.path.name = Image Path
+ImageNodes.property.path.description = \
+    The path to load images from. This should be the path to the folder \
+    that contains the images listed in the node's attributes.\n \
+    Images can be placed in subfolders, so long as the node's image attributes \
+    include the subfolder. 

--- a/modules/gephi-plugin-image-preview/src/main/resources/org/yale/cs/graphics/gephi/imagepreview/Bundle.properties
+++ b/modules/gephi-plugin-image-preview/src/main/resources/org/yale/cs/graphics/gephi/imagepreview/Bundle.properties
@@ -35,3 +35,13 @@ ImageNodes.property.path.description = \
     that contains the images listed in the node's attributes.\n \
     Images can be placed in subfolders, so long as the node's image attributes \
     include the subfolder. 
+
+ImageNodes.property.scale.name = Image Scale
+ImageNodes.property.scale.description = \
+    Scale the Images. Proportion from size are kept. 
+
+ImageNodePreviewConfigurationTopComponent.btn_image_directory.text=Choose Directory
+ImageNodePreviewConfigurationTopComponent.lb_image_directory.text=Directory Path :
+ImageNodePreviewConfigurationTopComponent.tf_image_directory.text=
+ImageNodePreviewConfigurationTopComponent.cb_use_directory.text=Use a directory
+ImageNodePreviewConfigurationTopComponent.lb_node_image_preview_configuration.text=Image Node Preview Configuration

--- a/pom.xml
+++ b/pom.xml
@@ -144,10 +144,13 @@
                 <configuration>
                     <nbmBuildDir>${clusters.path}</nbmBuildDir>
                     <licenseName>Apache 2.0</licenseName>
-                    <author>@totetmatt</author>
-                    <authorEmail>matthieu.totet@gmail.com</authorEmail>
-                    <authorUrl>http://matthieu-totet.fr/</authorUrl>
-                    <sourceCodeUrl>https://github.com/totetmatt/gephi-plugins/tree/twitter</sourceCodeUrl>
+                    <author>Yitzchak Lockerman (Yale Computer Graphics Group)</author>
+                    <sourceCodeUrl>$sourcecode_url</sourceCodeUrl>
+                    <licenseName>Apache 2.0</licenseName>
+                    <publicPackages> 
+                        <publicPackage>org.yale.cs.graphics.gephi.imagepreview</publicPackage>
+                    </publicPackages>
+                    <sourceCodeUrl>https://github.com/totetmatt/gephi-plugins/tree/image-preview</sourceCodeUrl>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <!-- List of modules -->
     <modules>
         <!-- Add here the paths of all modules (e.g. <module>modules/MyModule</module>) -->
+        <module>modules/gephi-plugin-image-preview</module>
     </modules>
     
     <!-- Properties -->
@@ -142,6 +143,11 @@
                 <artifactId>nbm-maven-plugin</artifactId>
                 <configuration>
                     <nbmBuildDir>${clusters.path}</nbmBuildDir>
+                    <licenseName>Apache 2.0</licenseName>
+                    <author>@totetmatt</author>
+                    <authorEmail>matthieu.totet@gmail.com</authorEmail>
+                    <authorUrl>http://matthieu-totet.fr/</authorUrl>
+                    <sourceCodeUrl>https://github.com/totetmatt/gephi-plugins/tree/twitter</sourceCodeUrl>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
== Transition to 0.9.X ==
Main work was to make the plugin transition to 0.9.X. 

Main issue was the `renderImageProcessing` (`ImageNode.java`) function as now the default rendering engine is `G2DTarget`. It makes the old Processing trick unusable anymore. Therefore, it's now using fully the `awt.Graphic2D` to render the image on preview and PNG rendering.

No big issue with PDF and SVG rendering.

== UX Changes ==
* Adding a `Scaling factor` that keep the size aspect but can resize the images only.
* The Default image directory used is your home/Document, if it's changed, the plugin keep the last Directory used even after a restart
* Alpha doesn't have any effect (didn't find correct method with Graphic2D)
* Some error handeling

== To Keep in Mind ==
* Didn't tried on lare graph (Maybe some Reuse of similar images could help ?)

Open to enhancement proposition before merging. 