### PR TITLE
Graphviz layout: always turn node IDs into string (issue #177)

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help the plugin developers
+title: ''
+labels: To review
+assignees: ''
+
+---
+
+## Which Plugin?
+
+## Expected Behavior
+
+## Current Behavior
+
+## Possible Solution
+
+<!--- Not obligatory, but suggest a fix/reason for the bug -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+4.
+
+## Context
+
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+
+## Your Environment
+
+* Gephi Version used: Gephi 0.10.0
+* Plugin Version used: 
+* Operating System: 
+
+<!--- Or preferably, include a copy of your messages.log file in your user directory (see https://github.com/gephi/gephi/wiki/Troubleshooting) -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## New plugin or plugin update?
+
+* [ ] New Plugin
+* [ ] Update
+
+## What is the purpose of this plugin?
+
+  
+## How to test your plugin in Gephi?
+
+1.
+2.
+
+## Checklist before submission
+
+* [ ] Did you merged with the `master` branch to get the latest updates?
+* [ ] Did you build and test the plugin successfully locally?
+* [ ] Did you include metadata (e.g. plugin author, license) in the `pom.xml` file
+* [ ] Did you make sure NOT to include any unecessary files in your PR?
+* [ ] Did you write unit tests to test your plugin functionalities?

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Submitting a Gephi plugin for approval is a simple process based on GitHub's [pu
 
 Updating a Gephi plugin has the same process as submitting it for the first time. Don't forget to merge from upstream's master branch.
 
-## IDE Support
+Also, make sure to increment the version number of your plugin in your module's `pom.xml` file before submitting.
 
-Although any IDE/Editor can be used, [Netbeans IDE](https://netbeans.org/) is recommended as Gephi itself is based on [Netbeans Platform](https://netbeans.org/features/platform/index.html).
+## IDE Support
 
 ### Netbeans IDE
 
@@ -97,11 +97,13 @@ To run Gephi with your plugin pre-installed when you click `Run`, create a `Mave
 
 To debug Gephi with your plugin, create a `Remote` configuration and switch the `Debugger mode` option to `Listen`. Then create a `Maven` run configuration like abobe but add `-Drun.params.debug="-J-Xdebug -J-Xnoagent -J-Xrunjdwp:transport=dt_socket,suspend=n,server=n,address=5005"` into the `Runner` > `VM Options` field. Then, go to the `Run` menu and first run debug with the remote configuration and then only run debug with the Maven configuration.
 
+When you make changes to your plugin and want to run Gephi with the changes, make sure to build the `gephi-plugins` root module, and not only your module. Otherwise, your changes won't be reflected.
+
 ## FAQ
 
 #### What kind of plugins can I create?
 
-Gephi can be extended in many ways but the major categories are `Layout`, `Export`, `Import`, `Data Laboratory`, `Filter`, `Generator`, `Metric`, `Preview`, `Tool`, `Appearance` and `Clustering`. A good way to start is to look at examples with the [bootcamp](https://github.com/gephi/gephi-plugins-bootcamp).
+Gephi can be extended in many ways but the major categories are `Layout`, `Export`, `Import`, `Data Laboratory`, `Filter`, `Generator`, `Metric`, `Preview`, `Tool` and `Appearance`. A good way to start is to look at examples with the [bootcamp](https://github.com/gephi/gephi-plugins-bootcamp).
 
 #### In which language can plugins be created?
 
@@ -115,9 +117,9 @@ Yes, native libraries can be used in modules.
 
 The `modules` folder is where plugin modules go. Each plugin is defined in a single folder in this directory. A plugin can be composed of multiple modules (it's called a suite then) but usually one is enough to do what you want.
 
-The `pom.xml` file in `modules` is the parent pom for plugins. A Maven pom can inherit configurations from a parent and that is something we use to keep each plugin's pom very simple. Notice that each plugin's pom (i.e. the `pom.xml` file in the plugin folder) has a `<parent>` defined.
+A Maven pom can inherit configurations from a parent and that is something we use to keep each plugin's pom very simple. Notice that each plugin's pom (i.e. the `pom.xml` file in the plugin folder) has a `<parent>` defined.
 
-The `pom.xml` file at the root folder makes everything fit together and notably lists the modules.
+The `pom.xml` file at the root folder makes everything fit together and notably lists the modules. No need to change anything there besides the `<modules>...</modules>` list.
 
 #### How are the manifest settings defined?
 
@@ -141,7 +143,7 @@ This applies for suite plugins with multiple modules. Besides creating the modul
 
 Dependencies are configured in the `<dependencies>` section in the plugin folder's `pom.xml`. Each dependency has a `groupId`, an `artifactId` and a `version`. There are three types of dependencies a plugin can have: an external library, a Gephi module or a Netbeans module.
 
-The list of Gephi and Netbeans dependencies one can use can be found in the `modules/pom.xml` file. All possible dependencies are listed in the `<dependencyManagement>` section. Because each plugin module inherits from this parent pom the version can be omitted when the dependency is set. For instance, this is how a plugin depends on `GraphAPI` and Netbeans's `Lookup`.
+The list of Gephi and Netbeans dependencies one can use can be found in the parent POM, which you can browse [here](https://github.com/gephi/gephi-plugins/blob/6136ba8427349aa16c4f4b94265267fc3de0e767/modules/pom.xml#L76). All possible dependencies are listed in the `<dependencyManagement>` section. Because each plugin module already inherits the version from this parent pom, it can be omitted. For instance, this is how a plugin depends on `GraphAPI` and Netbeans's `Lookup`.
 
 ```
 <dependencies>
@@ -155,6 +157,22 @@ The list of Gephi and Netbeans dependencies one can use can be found in the `mod
     </dependency>
 </dependencies>
 ```
+
+#### How to best write unit tests for my plugin?
+
+It's recommended to use unit-testing to ensure a reliable plugin.
+
+A JUnit4 dependency can be added to your module's `pom.xml`
+
+```
+<dependency>
+    <groupId>org.netbeans.api</groupId>
+    <artifactId>org-netbeans-modules-nbjunit</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+Those tests will automatically be run when your plugin is built.
 
 #### What are public packages for?
 
@@ -170,36 +188,8 @@ Public packages are configured in the module's `pom.xml` file. Edit the `<public
 
 #### What is the difference between plugin and module?
 
-It's the same thing. We say module because Gephi is a modular application and is composed of many independent modules. Plugins also are modules, but we call them plugin because they aren't in the _core_ Gephi.
+It's the same thing. We say module because Gephi is a modular application and is composed of many independent modules. Plugins also are modules but we call them plugin because they aren't in the _core_ Gephi.
 
 #### When running the plugin in Netbeans I get an error "Running standalone modules or suites requires..."
 
 This error appears when you try to run a module. To run Gephi with your plugin you need to run the `gephi-plugins` project, not your module.
-
-## Migrate Gephi 0.8 plugins
-
-The process in which plugins are developed and submitted had an overhaul when Gephi 0.9 was released. Details can be read on this article: [Plugin development gets new tools and opens-up to the community](https://gephi.wordpress.com/2015/12/16/plugin-development-gets-new-tools-and-opens-up-to-the-community/).
-
-This section is a step-by-step guide to migrate 0.8 plugins. Before going through the code and configuration, let's summerize the key differences between the two environements.
-
-- The 0.8 base is built using Ant, whereas the 0.9 uses Maven. These two are significantly different. If you aren't familiar with Maven, you can start with [Maven in 5 Minutes]( https://maven.apache.org/guides/getting-started/maven-in-five-minutes.html). Maven configurations are defined in the `pom.xml` files.
-- The 0.8 base finds the Gephi modules into the `platform` folder checked in the repository, whereas the 0.9 base downloads everything from the central Maven repository, where all Gephi modules are available.
-- Maven requires to separate source files (e.g. .java) and resources files (e.g. .properties) into distinct folders. Sources are located in `src/main/java` and resources in `src/main/resources`.
-
-A custom `migrate` goal is available in the [Gephi Maven Plugin](https://github.com/gephi/gephi-maven-plugin) to facilitate the migration from 0.8 to 0.9. This automated process migrates ant-based plugins to maven and takes care of copying the configuration and code. Follow these steps to migrate your plugin:
-
-- Fork and checkout this repository:
-
-        git clone git@github.com:username/gephi-plugins.git
-
-If you've already had a forked repository based on 0.8 we suggest to save your code somewhere, delete it and fork again as the history was cleared.
-
-- Copy your plugin folder at the root of this directory.
-
-- Run this command:
-
-        mvn org.gephi:gephi-maven-plugin:migrate
-
-This command will detect the ant-based plugin and migrate it. The resulting folder is then located into the `modules` folder.
-
-The plugin code can then be inspected in Netbeans or built via command line with `mvn clean package`.

--- a/modules/GraphvizLayout/pom.xml
+++ b/modules/GraphvizLayout/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.icculus.chunky</groupId>
     <artifactId>gephigraphviz</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>nbm</packaging>
 
     <name>GraphvizLayout</name>

--- a/modules/GraphvizLayout/src/main/java/org/icculus/chunky/gephigraphviz/GraphvizLayout.java
+++ b/modules/GraphvizLayout/src/main/java/org/icculus/chunky/gephigraphviz/GraphvizLayout.java
@@ -105,15 +105,15 @@ public class GraphvizLayout extends AbstractLayout implements Layout {
             graph.readLock();
         
             for (final Node n : this.graph.getNodes()) {
-                dotfile.append(n.getId());
+		dotfile.append("\"").append(n.getId()).append("\"");
                 dotfile.append(" [");
                 dotfile.append("pos=\"").append(n.x()).append(',').append(n.y()).append('"');
                 dotfile.append("];\n");
             }
             for (final Edge e : this.graph.getEdges()) {
-                dotfile.append(e.getSource().getId());
+		dotfile.append("\"").append(e.getSource().getId()).append("\"");
                 dotfile.append(edgearrow);
-                dotfile.append(e.getTarget().getId());
+		dotfile.append("\"").append(e.getTarget().getId()).append("\"");
                 dotfile.append(" [weight=");
                 dotfile.append(e.getWeight());
                 dotfile.append("];\n");
@@ -266,7 +266,7 @@ public class GraphvizLayout extends AbstractLayout implements Layout {
                 entireOutput.append("\n");
             }
             
-            final String regex = "^\\s*(?<nodeid>\\S+)\\s+\\[[^\\]]*?[, ]?pos=\"(?<pos>[^\"]+?)\".*?\\]";
+	    final String regex = "^\\s*\"(?<nodeid>\\S+)\"\\s+\\[[^\\]]*?[, ]?pos=\"(?<pos>[^\"]+?)\".*?\\]";
             final Pattern pat = Pattern.compile(regex, Pattern.MULTILINE | Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
             Matcher matcher = pat.matcher(entireOutput.toString());
             while(matcher.find()) {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.gephi</groupId>
     <artifactId>gephi-plugins</artifactId>
-    <version>0.9.3</version>
+    <version>0.10.0</version>
     <packaging>pom</packaging>
 
     <name>gephi-plugins</name>
@@ -18,7 +18,7 @@
     <!-- Properties -->
     <properties>
         <!-- Version of Gephi building plugins against. Plugins with anterior versions will be ignored -->
-        <gephi.version>0.9.3</gephi.version>
+        <gephi.version>0.10.0</gephi.version>
         <clusters.path>${project.build.directory}/plugins_clusters</clusters.path>
         <github.global.server>github</github.global.server>
     </properties>
@@ -91,7 +91,7 @@
                 <plugin>
                     <groupId>org.gephi</groupId>
                     <artifactId>gephi-maven-plugin</artifactId>
-                    <version>1.3.3</version>
+                    <version>1.3.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## New plugin or plugin update?

* [ ] New Plugin
* [x] Update

## What is the purpose of this plugin?
Fixing issue #177 by always making the node ids in the dot file strings.
  
## How to test your plugin in Gephi?

1. compile with `mvn clean package`
2. install the plugin `modules/GraphvizLayout/target/nbm/gephigraphviz-1.0.0.nbm` into Gephi

## Checklist before submission

* [x] Did you merged with the `master` branch to get the latest updates?
* [x] Did you build and test the plugin successfully locally?
* [ ] Did you include metadata (e.g. plugin author, license) in the `pom.xml` file
* [x] Did you make sure NOT to include any unecessary files in your PR?
* [ ] Did you write unit tests to test your plugin functionalities?
